### PR TITLE
add linux path suffix to isPythonPath check

### DIFF
--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -346,8 +346,8 @@ export class ManimSideview {
         }
 
         // Check if the environment path is a direct path to the Python executable
-        const normalizedPath = path.normalize(env.folderUri.fsPath);
-        const isPythonPath = ["/bin/python", "\\bin\\python", "\\Scripts\\python.exe"].some(
+        const normalizedPath = path.win32.normalize(env.folderUri.fsPath);
+        const isPythonPath = ["\\bin\\python", "\\Scripts\\python.exe"].some(
           (execPath) => normalizedPath.endsWith(execPath)
         );
 


### PR DESCRIPTION
Unfortunately, the `isPythonPath` check does not work on linux because the path has `/` instead of `\`.

I solved it now in the most straight foreward way by just also adding the linux variant.

Another way of solving this would be something similar like this if it is desired:
``` python
import path from "path";

function isPythonBin(p) {
  // Normalize separators and resolve weirdness like "./" or "../"
  const normalized = path.normalize(p);

  // Extract the last two path segments
  const parts = normalized.split(path.sep);
  const last = parts[parts.length - 1];
  const secondLast = parts[parts.length - 2];

  return (
    secondLast === "bin" &&
    (last === "python" || last === "python.exe")
  );
}

// Examples
console.log(isPythonBin("C:\\Users\\me\\project\\bin\\python"));     // true
console.log(isPythonBin("C:/Users/me/project/bin/python.exe"));     // true
console.log(isPythonBin("/usr/local/bin/python"));                  // true
console.log(isPythonBin("/usr/local/bin/python3"));                 // false
```
~ Credit ChatGPT