### PR TITLE
Support audio

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         },
         "manim-sideview.commandLineArgs": {
           "type": "string",
+          "default": "--format mov",
           "description": "Input additional command line arguments for Manim. Refer to Manim documentation for options. Use the config file for quality args like 'ql'."
         },
         "manim-sideview.runOnSave": {

--- a/src/player.ts
+++ b/src/player.ts
@@ -139,7 +139,7 @@ export class MediaPlayer {
         getUserConfiguration("previewProgressColor")
       ),
       loop: getUserConfiguration("previewLooping") ? "loop" : "",
-      autoplay: getUserConfiguration("previewAutoPlay") ? "autoplay muted" : "",
+      autoplay: getUserConfiguration("previewAutoPlay") ? "autoplay" : "",
     });
     Log.info(`Playing media URI "${mediaUri.fsPath}"`);
 


### PR DESCRIPTION
Supports audio by changing the output format to `mov` and removing `autoplay muted`.

## Example
```py
from manim import *
class TestScene(Scene):
    def construct(self) -> None:
        self.add_sound("audio.wav")
        circle = Circle()
        self.add(circle)
        self.wait(6)
```
[audio.wav](https://github.com/user-attachments/files/29131847/audio.wav)

## Problems

* Autoplay doesnt work any more.
* There is probably a better way to set `mov` as the output format.

Close #107 