### PR TITLE
chore: 0.4.0 release with cfg trim, env PATH, and version-default fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run compile
+      - run: npm run test:unit
+
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: npm ci
+      # manimpango has no linux wheels; it builds against pango headers
+      - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config
+      - run: pip install "manim>=0.19"
+      - run: npm run test:contract

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from "@vscode/test-cli";
 
 export default defineConfig({
-  files: "out/test/**/*.test.js",
+  files: "out/test/suite/**/*.test.js",
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+## 0.4.0
+
+### Output path resolution
+
+The extension no longer recomputes the render output path from static
+configuration alone. It now prefers the actual path manim reports in its
+"File ready at" log line, and when logs are unavailable (e.g. low verbosity)
+it probes both the predicted video and image paths on disk and picks the
+most recently modified one.
+
+This fixes a long-standing family of "Predicted output file does not exist"
+errors:
+
+- Quality flags such as `-ql` / `-qm` passed through `commandLineArgs` now
+  resolve to the correct quality folder (#99, #132)
+- Resolution overrides set inside the Python file via `config.pixel_width` /
+  `config.pixel_height` are respected (#115)
+- Scenes that output an image are detected even when `verbosity` is set to
+  `WARNING` or `ERROR`; when both an image and a stale video exist, the newer
+  file wins (#139)
+
+### Environment and executable discovery
+
+- Virtual environment executable discovery now uses the interpreter path
+  reported by the Python extension, fixing venv lookups on Linux and macOS
+  (#130, #134)
+- When `defaultManimPath` points at a directory (such as a Windows `Scripts`
+  folder, including Microsoft Store Python installs), the manim executable
+  name is appended instead of attempting to spawn the directory (#127, #133)
+- The interpreter's bin directory is placed on the spawned process PATH so
+  tools installed alongside manim, like ffmpeg in conda or venv environments,
+  are found even when they are not on the global PATH (#98)
+
+### Fixes
+
+- Values in `manim.cfg` are trimmed, so trailing whitespace such as
+  `quality = low_quality ` no longer fails the render (#137)
+- The source file is checked for existence before rendering
+- The default `manimExecutableVersion` was bumped from `v0.16.0.post0` to
+  `v0.19.0` so image filename prediction matches current manim releases

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,49 @@
+# Testing
+
+Three tiers, from fastest to most end-to-end. Fixtures for all tiers live
+in `src/test/fixtures/`.
+
+## 1. Unit tests (no manim, no VSCode)
+
+```
+npm run test:unit
+```
+
+Compiles the sources and runs `src/test/unit/` with Node's built-in test
+runner. Covers the output-resolution logic (`src/mediaResolution.ts`) against
+recorded manim log samples in `src/test/fixtures/logs/`, the disk-probe
+fallback, and path prediction in `src/globals.ts` behind a vscode stub.
+
+## 2. Contract tests (real manim, no VSCode)
+
+```
+npm run test:contract
+```
+
+Renders the fixture scenes with the local manim installation (override the
+binary with `MANIM_BIN=/path/to/manim`) in a temp directory and feeds the
+live output through the extension's actual resolution code. This catches
+drift in manim's "File ready at" log format, which path prediction relies
+on. Cases: video render with `-ql`, image render, silent logs under
+`verbosity = WARNING` (disk probe), and a `manim.cfg` with trailing
+whitespace in the quality value.
+
+## 3. Manual checks (Extension Development Host)
+
+Press F5 in this repo, then in the dev host window open the fixture folder
+listed per row. All fixtures render in under a minute at low quality.
+
+| Scenario | Setup | Expect |
+| --- | --- | --- |
+| Quality flag via settings (#99, #132) | Open `src/test/fixtures/scenes/`, set `manim-sideview.commandLineArgs` to `-ql`, render `video_scene.py` scene `VideoScene` | 480p15 video previews without a predicted-path error |
+| In-file resolution override (#115) | Open `src/test/fixtures/issues/115_custom_resolution/`, render `scene.py` scene `VerticalScene` | 1080x1920 video previews |
+| Silent logs, image output (#139) | Open `src/test/fixtures/issues/139_low_verbosity/`, render `scene.py` scene `ImageScene`; set `manim-sideview.manimExecutableVersion` to your manim version if not v0.19.0 | image previews, no stale-video preview, no error |
+| Trailing whitespace in cfg (#137) | Open `src/test/fixtures/issues/137_trailing_space/`, render `scene.py` scene `VideoScene` | renders normally, no "quality is invalid" error |
+| Env-local ffmpeg (#98) | conda or venv with ffmpeg installed inside it and not on the global PATH; set `manim-sideview.defaultManimPath` to that env's `bin/manim` | no pydub ffmpeg warning, render completes |
+| Scripts directory as manim path (#127, #133) | Windows: set `manim-sideview.defaultManimPath` to a `Scripts` directory containing manim.exe | manim resolved inside the directory, render runs |
+
+## CI
+
+`.github/workflows/ci.yml` runs lint, both compile targets, and the unit
+tests on every push and pull request, and the contract tests against a real
+pip-installed manim on ubuntu.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-sideview",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-sideview",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
         "axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "name": "Ricky",
     "url": "https://github.com/Rickaym"
   },
-  "version": "0.3.1",
+  "version": "0.4.0",
   "publisher": "Rickaym",
   "engines": {
     "vscode": "^1.68.0"
@@ -92,7 +92,7 @@
         },
         "manim-sideview.manimExecutableVersion": {
           "type": "string",
-          "default": "v0.16.0.post0",
+          "default": "v0.19.0",
           "description": "Specify the version of the Manim executable used by the extension."
         },
         "manim-sideview.terminalCommand": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,9 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "test:unit": "npm run compile-tests && node --test out/test/unit/",
+    "test:contract": "npm run compile-tests && node scripts/contract-test.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.6",

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -127,7 +127,7 @@ function check(name, fn) {
   check("silent logs: disk probe finds the rendered image", () => {
     // predicted names mirror globals.getImageOutputPath with the real version
     const versionTag = (version.stdout.trim() || version.stderr.trim())
-      .match(/v[\d.]+(\.post\d+)?/)?.[0];
+      .match(/v\d+(\.\d+)*(\.post\d+)?/)?.[0];
     assert.ok(versionTag, "could not parse manim version");
     const predictedImage = path.join(
       cwd,

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -1,0 +1,183 @@
+/**
+ * Contract test: renders fixture scenes with a real manim installation and
+ * feeds the live stdout through the extension's actual output-resolution
+ * code (out/mediaResolution.js). Catches drift in manim's log format, which
+ * path prediction depends on.
+ *
+ * Requires: manim on PATH (or MANIM_BIN set) and a prior `npm run
+ * compile-tests`. Renders into a temp directory; the repo stays clean.
+ */
+
+const { spawnSync } = require("child_process");
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const REPO = path.join(__dirname, "..");
+const MANIM = process.env.MANIM_BIN || "manim";
+const FIXTURES = path.join(REPO, "src", "test", "fixtures");
+
+const {
+  parseMediaOutputFromLog,
+  probeMediaOnDisk,
+} = require(path.join(REPO, "out", "mediaResolution.js"));
+
+function run(args, cwd) {
+  const result = spawnSync(MANIM, args, {
+    cwd,
+    encoding: "utf-8",
+    timeout: 300000,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return result;
+}
+
+function freshDir(name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `msv-contract-${name}-`));
+  return dir;
+}
+
+const version = run(["--version"], REPO);
+console.log(`manim: ${version.stdout.trim() || version.stderr.trim()}`);
+
+let failures = 0;
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`[PASS] ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`[FAIL] ${name}\n${err.message}`);
+  }
+}
+
+// 1. video render: the logged path must parse and exist
+{
+  const cwd = freshDir("video");
+  fs.copyFileSync(
+    path.join(FIXTURES, "scenes", "video_scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  const render = run(["-ql", "scene.py", "VideoScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("video: File ready path parses from real manim output", () => {
+    const parsed = parseMediaOutputFromLog(logbook);
+    assert.ok(parsed, `no File ready entry found in:\n${logbook}`);
+    assert.strictEqual(parsed.isImage, false);
+    assert.ok(
+      fs.existsSync(parsed.mediaPath),
+      `parsed path does not exist: ${parsed.mediaPath}`
+    );
+    assert.ok(
+      parsed.mediaPath.includes("480p15"),
+      `-ql should land in 480p15, got: ${parsed.mediaPath}`
+    );
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
+// 2. image render: detected as an image from the logs
+{
+  const cwd = freshDir("image");
+  fs.copyFileSync(
+    path.join(FIXTURES, "scenes", "image_scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  const render = run(["-ql", "scene.py", "ImageScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("image: detected as image with an existing path", () => {
+    const parsed = parseMediaOutputFromLog(logbook);
+    assert.ok(parsed, `no File ready entry found in:\n${logbook}`);
+    assert.strictEqual(parsed.isImage, true);
+    assert.ok(
+      fs.existsSync(parsed.mediaPath),
+      `parsed path does not exist: ${parsed.mediaPath}`
+    );
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
+// 3. verbosity WARNING: logs are silent, the disk probe must find the image
+{
+  const cwd = freshDir("silent");
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "139_low_verbosity", "scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "139_low_verbosity", "manim.cfg"),
+    path.join(cwd, "manim.cfg")
+  );
+  const render = run(["-ql", "scene.py", "ImageScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("silent logs: no File ready entry leaks through", () => {
+    assert.strictEqual(
+      parseMediaOutputFromLog(logbook),
+      null,
+      `expected silent logs, got:\n${logbook}`
+    );
+  });
+
+  check("silent logs: disk probe finds the rendered image", () => {
+    // predicted names mirror globals.getImageOutputPath with the real version
+    const versionTag = (version.stdout.trim() || version.stderr.trim())
+      .match(/v[\d.]+(\.post\d+)?/)?.[0];
+    assert.ok(versionTag, "could not parse manim version");
+    const predictedImage = path.join(
+      cwd,
+      "media",
+      "images",
+      "scene",
+      `ImageScene_ManimCE_${versionTag}.png`
+    );
+    const predictedVideo = path.join(
+      cwd,
+      "media",
+      "videos",
+      "scene",
+      "480p15",
+      "ImageScene.mp4"
+    );
+    const probed = probeMediaOnDisk(predictedVideo, predictedImage);
+    assert.ok(
+      probed,
+      `probe found nothing; media tree: ${JSON.stringify(
+        fs.readdirSync(path.join(cwd, "media"), { recursive: true })
+      )}`
+    );
+    assert.strictEqual(probed.isImage, true);
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
+// 4. trailing whitespace in manim.cfg quality still renders (issue #137)
+{
+  const cwd = freshDir("trim");
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "137_trailing_space", "scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "137_trailing_space", "manim.cfg"),
+    path.join(cwd, "manim.cfg")
+  );
+  const render = run(["scene.py", "VideoScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("trailing-space quality: manim renders and path parses", () => {
+    assert.strictEqual(render.status, 0, `manim exited ${render.status}:\n${logbook}`);
+    const parsed = parseMediaOutputFromLog(logbook);
+    assert.ok(parsed, `no File ready entry found in:\n${logbook}`);
+    assert.ok(fs.existsSync(parsed.mediaPath));
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
+console.log(failures === 0 ? "\nCONTRACT TESTS PASSED" : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/mediaResolution.ts
+++ b/src/mediaResolution.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs";
+
+/**
+ * Pure helpers for locating the rendered output file. Kept free of any
+ * vscode dependency so they can be unit tested directly.
+ */
+
+export const RE_FILE_READY = /File\s*ready\s*at[^']*'(?<path>[^']*)'/g;
+
+export type ResolvedMedia = {
+  isImage: boolean;
+  mediaPath: string;
+};
+
+// manim wraps long paths across lines inside the quotes; strip the
+// wrapping whitespace to recover the real path
+function cleanPath(p: string): string {
+  return p.replace(/ |\r|\n/g, "");
+}
+
+/**
+ * Finds the output file manim reported in its logs.
+ *
+ * Prefers an image entry if present; otherwise takes the last "File ready
+ * at" entry, since videos log one line per partial movie file plus a final
+ * entry for the merged output.
+ */
+export function parseMediaOutputFromLog(
+  stdoutLogbook: string
+): ResolvedMedia | null {
+  const matches = [...stdoutLogbook.matchAll(RE_FILE_READY)];
+  if (matches.length === 0) {
+    return null;
+  }
+  const imageEntry = matches.find((m) =>
+    cleanPath(m.groups?.path ?? "").endsWith(".png")
+  );
+  const chosen = imageEntry ?? matches[matches.length - 1];
+  return {
+    isImage: !!imageEntry,
+    mediaPath: cleanPath(chosen.groups?.path ?? ""),
+  };
+}
+
+/**
+ * Fallback for when manim's logs are silent (e.g. verbosity WARNING or
+ * ERROR): probe both predicted paths on disk and pick whichever exists,
+ * preferring the most recently modified.
+ */
+export function probeMediaOnDisk(
+  predictedVideo: string,
+  predictedImage: string
+): ResolvedMedia | null {
+  const videoMtime = fs.existsSync(predictedVideo)
+    ? fs.statSync(predictedVideo).mtimeMs
+    : undefined;
+  const imageMtime = fs.existsSync(predictedImage)
+    ? fs.statSync(predictedImage).mtimeMs
+    : undefined;
+  if (
+    imageMtime !== undefined &&
+    (videoMtime === undefined || imageMtime >= videoMtime)
+  ) {
+    return { isImage: true, mediaPath: predictedImage };
+  }
+  if (videoMtime !== undefined) {
+    return { isImage: false, mediaPath: predictedVideo };
+  }
+  return null;
+}
+
+export function baseName(mediaPath: string): string | undefined {
+  return mediaPath.split(/\\|\//g).pop();
+}

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -1024,10 +1024,10 @@ export class ManimSideview {
 
     for (const flag of RELEVANT_CONFIG_OPTIONS) {
       if (parsedConfig.hasKey(CONFIG_SECTION, flag)) {
-        manimConfig[flag as keyof ManimConfig] = parsedConfig.get(
-          CONFIG_SECTION,
-          flag
-        )!;
+        // trim to tolerate trailing whitespace, e.g. "low_quality " (#137)
+        manimConfig[flag as keyof ManimConfig] = parsedConfig
+          .get(CONFIG_SECTION, flag)!
+          .trim();
         Log.info(
           `Set flag "${flag}" to ${parsedConfig.get(CONFIG_SECTION, flag)}.`
         );

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -25,6 +25,11 @@ import { Gallery } from "./gallery";
 import { ManimPseudoTerm } from "./pseudoTerm";
 import { PythonExtension } from "@vscode/python-extension";
 import { window } from "vscode";
+import {
+  parseMediaOutputFromLog,
+  probeMediaOnDisk,
+  baseName,
+} from "./mediaResolution";
 
 const CONFIG_SECTION = "CLI";
 const RELEVANT_CONFIG_OPTIONS = [
@@ -36,11 +41,6 @@ const RELEVANT_CONFIG_OPTIONS = [
   "video_dir",
   "images_dir",
 ];
-import {
-  parseMediaOutputFromLog,
-  probeMediaOnDisk,
-  baseName,
-} from "./mediaResolution";
 
 const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*Scene\b[\w,\s]*\):/g;
 const RE_CFG_OPTIONS = /(\w+)\s?:\s?([^ ]*)/g;

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -92,34 +92,47 @@ function quoteSpecialChars(text: string): string {
  * resolution; `conda-meta` at the prefix root is the marker all conda-style
  * managers share.
  *
+ * For non-conda installs, falls back to prepending the interpreter's bin
+ * directory when one is known, so tools installed next to manim (ffmpeg in
+ * venv environments) are found (#98).
+ *
  * @param manimExe absolute path to the manim executable being spawned
- * @returns an environment with activation paths injected, or undefined to
- * inherit the parent environment untouched (non-conda installs)
+ * @param binDir the interpreter's bin directory, if known
+ * @returns an environment with the needed paths injected, or undefined to
+ * inherit the parent environment untouched
  */
 function getActivationEnvironment(
-  manimExe: string
+  manimExe: string,
+  binDir?: string
 ): NodeJS.ProcessEnv | undefined {
-  if (!path.isAbsolute(manimExe)) {
-    return undefined;
-  }
-  // <prefix>/Scripts/manim.exe (win32) or <prefix>/bin/manim (unix)
-  const prefix = path.dirname(path.dirname(manimExe));
-  if (!fs.existsSync(path.join(prefix, "conda-meta"))) {
-    return undefined;
+  let prefix: string | undefined;
+  if (path.isAbsolute(manimExe)) {
+    // <prefix>/Scripts/manim.exe (win32) or <prefix>/bin/manim (unix)
+    const candidate = path.dirname(path.dirname(manimExe));
+    if (fs.existsSync(path.join(candidate, "conda-meta"))) {
+      prefix = candidate;
+    }
   }
 
-  // The same directories conda activation prepends to PATH, in its order.
-  const binDirs =
-    process.platform === "win32"
-      ? [
-          prefix,
-          path.join(prefix, "Library", "mingw-w64", "bin"),
-          path.join(prefix, "Library", "usr", "bin"),
-          path.join(prefix, "Library", "bin"),
-          path.join(prefix, "Scripts"),
-          path.join(prefix, "bin"),
-        ]
-      : [path.join(prefix, "bin")];
+  let binDirs: string[];
+  if (prefix) {
+    // The same directories conda activation prepends to PATH, in its order.
+    binDirs =
+      process.platform === "win32"
+        ? [
+            prefix,
+            path.join(prefix, "Library", "mingw-w64", "bin"),
+            path.join(prefix, "Library", "usr", "bin"),
+            path.join(prefix, "Library", "bin"),
+            path.join(prefix, "Scripts"),
+            path.join(prefix, "bin"),
+          ]
+        : [path.join(prefix, "bin")];
+  } else if (binDir) {
+    binDirs = [binDir];
+  } else {
+    return undefined;
+  }
 
   const env: NodeJS.ProcessEnv = { ...process.env };
   // On Windows the inherited key may be spelled "Path"; reuse it to avoid
@@ -128,10 +141,12 @@ function getActivationEnvironment(
     Object.keys(env).find((key) => key.toUpperCase() === "PATH") || "PATH";
   env[pathKey] =
     binDirs.join(path.delimiter) + path.delimiter + (env[pathKey] || "");
-  env.CONDA_PREFIX = prefix;
-  Log.info(
-    `Detected conda-style environment at "${prefix}"; spawning manim with activation paths injected.`
-  );
+  if (prefix) {
+    env.CONDA_PREFIX = prefix;
+    Log.info(
+      `Detected conda-style environment at "${prefix}"; spawning manim with activation paths injected.`
+    );
+  }
   return env;
 }
 
@@ -397,6 +412,7 @@ export class ManimSideview {
       manimPath = "manim";
     }
     let envName = null;
+    let pythonBinDir: string | undefined;
 
     Log.info(`Default manim path is found as "${manimPath}"`);
 
@@ -420,7 +436,6 @@ export class ManimSideview {
         // Prefer the canonical interpreter path from the Python extension API.
         // Fall back to the env folder + platform bin dir only if the API doesn't
         // expose an executable (rare: envs created without a python interpreter).
-        let pythonBinDir: string | undefined;
         const executableUri = env.executable?.uri;
         if (executableUri) {
           pythonBinDir = path.dirname(executableUri.fsPath);
@@ -471,7 +486,13 @@ export class ManimSideview {
         throw Error(msg);
       }
     }
-    return { manim: manimPath, envName };
+
+    // An absolute manim path implies its siblings (ffmpeg on conda/venv
+    // installs) live in the same folder; expose it for the spawn PATH (#98).
+    if (!pythonBinDir && path.isAbsolute(manimPath)) {
+      pythonBinDir = path.dirname(manimPath);
+    }
+    return { manim: manimPath, envName, binDir: pythonBinDir };
   }
 
   async cmdUpdateDefaultManimConfig() {
@@ -623,6 +644,7 @@ export class ManimSideview {
       manim.manim,
       args,
       cwd,
+      manim.binDir,
       config.srcPath,
       config.sceneName,
       (mediaInfo) => {
@@ -711,6 +733,7 @@ export class ManimSideview {
     command: string,
     args: string[],
     cwd: string,
+    binDir: string | undefined,
     srcPath: string,
     sceneName: string,
     onProcessClose: (m: MediaInfo) => void
@@ -719,7 +742,7 @@ export class ManimSideview {
     const process = spawn(command, args, {
       cwd: cwd,
       shell: false,
-      env: getActivationEnvironment(command),
+      env: getActivationEnvironment(command, binDir),
     });
     const job = this.jobManager.getActiveJob(srcPath);
 

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -36,9 +36,14 @@ const RELEVANT_CONFIG_OPTIONS = [
   "video_dir",
   "images_dir",
 ];
+import {
+  parseMediaOutputFromLog,
+  probeMediaOnDisk,
+  baseName,
+} from "./mediaResolution";
+
 const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*Scene\b[\w,\s]*\):/g;
 const RE_CFG_OPTIONS = /(\w+)\s?:\s?([^ ]*)/g;
-const RE_FILE_READY = /File\s*ready\s*at[^']*'(?<path>[^']*)'/g;
 
 const PYTHON_ENV_SCRIPTS_FOLDER = {
   win32: "Scripts",
@@ -892,56 +897,37 @@ export class ManimSideview {
     Log.info(`Attempting to determine the output file type for "${sceneName}".`);
 
     // the file output signifier
-    const fileReSignifier = [...stdoutLogbook.matchAll(RE_FILE_READY)];
-    if (fileReSignifier.length > 0) {
-      // Prefer the last "File ready at" entry — for videos manim emits one per
-      // partial movie file plus a final entry for the merged output.
-      const cleanPath = (p: string) => p.replace(/ |\r|\n/g, "");
-      const imageEntry = fileReSignifier.find((m) =>
-        cleanPath(m.groups?.path ?? "").endsWith(".png")
-      );
-      const fileIdentifier = imageEntry ?? fileReSignifier[fileReSignifier.length - 1];
-      const fullPath = cleanPath(fileIdentifier.groups?.path ?? "");
-      if (imageEntry) {
-        fileType = PlayableMediaType.Image;
-        imageName = fullPath.split(/\\|\//g).pop();
-      } else {
-        fileType = PlayableMediaType.Video;
+    const logged = parseMediaOutputFromLog(stdoutLogbook);
+    if (logged) {
+      fileType = logged.isImage
+        ? PlayableMediaType.Image
+        : PlayableMediaType.Video;
+      if (logged.isImage) {
+        imageName = baseName(logged.mediaPath);
       }
-      if (fullPath) {
-        mediaPath = fullPath;
+      if (logged.mediaPath) {
+        mediaPath = logged.mediaPath;
       }
       Log.info(
-        `[${process.pid}] Render output is predicted as "${fileType === PlayableMediaType.Image ? "Image" : "Video"
-        }" at "${fullPath}".`
+        `[${process.pid}] Render output is predicted as "${logged.isImage ? "Image" : "Video"
+        }" at "${logged.mediaPath}".`
       );
     } else {
       // Probe both predicted paths on disk and pick whichever exists.
-      const predictedVideo = path.join(
-        job.config.srcRootFolder,
-        getVideoOutputPath(job.config)
+      const probed = probeMediaOnDisk(
+        path.join(job.config.srcRootFolder, getVideoOutputPath(job.config)),
+        path.join(job.config.srcRootFolder, getImageOutputPath(job.config))
       );
-      const predictedImage = path.join(
-        job.config.srcRootFolder,
-        getImageOutputPath(job.config)
-      );
-      const videoMtime = fs.existsSync(predictedVideo)
-        ? fs.statSync(predictedVideo).mtimeMs
-        : undefined;
-      const imageMtime = fs.existsSync(predictedImage)
-        ? fs.statSync(predictedImage).mtimeMs
-        : undefined;
-      if (imageMtime !== undefined && (videoMtime === undefined || imageMtime >= videoMtime)) {
-        fileType = PlayableMediaType.Image;
-        imageName = path.basename(predictedImage);
-        mediaPath = predictedImage;
-      } else if (videoMtime !== undefined) {
-        fileType = PlayableMediaType.Video;
-        mediaPath = predictedVideo;
-      }
-      if (fileType !== undefined) {
+      if (probed) {
+        fileType = probed.isImage
+          ? PlayableMediaType.Image
+          : PlayableMediaType.Video;
+        if (probed.isImage) {
+          imageName = path.basename(probed.mediaPath);
+        }
+        mediaPath = probed.mediaPath;
         Log.info(
-          `[${process.pid}] Render output inferred from filesystem as "${fileType === PlayableMediaType.Image ? "Image" : "Video"
+          `[${process.pid}] Render output inferred from filesystem as "${probed.isImage ? "Image" : "Video"
           }".`
         );
       }

--- a/src/test/fixtures/issues/115_custom_resolution/scene.py
+++ b/src/test/fixtures/issues/115_custom_resolution/scene.py
@@ -1,0 +1,11 @@
+from manim import *
+
+config.pixel_width = 1080
+config.pixel_height = 1920
+config.frame_width = 9.0
+config.frame_height = 16.0
+
+
+class VerticalScene(Scene):
+    def construct(self):
+        self.play(Create(Square()), run_time=0.5)

--- a/src/test/fixtures/issues/137_trailing_space/manim.cfg
+++ b/src/test/fixtures/issues/137_trailing_space/manim.cfg
@@ -1,0 +1,2 @@
+[CLI]
+quality = low_quality 

--- a/src/test/fixtures/issues/137_trailing_space/scene.py
+++ b/src/test/fixtures/issues/137_trailing_space/scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class VideoScene(Scene):
+    def construct(self):
+        self.play(Create(Circle()), run_time=0.5)

--- a/src/test/fixtures/issues/139_low_verbosity/manim.cfg
+++ b/src/test/fixtures/issues/139_low_verbosity/manim.cfg
@@ -1,0 +1,2 @@
+[CLI]
+verbosity = WARNING

--- a/src/test/fixtures/issues/139_low_verbosity/scene.py
+++ b/src/test/fixtures/issues/139_low_verbosity/scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class ImageScene(Scene):
+    def construct(self):
+        self.add(Circle())

--- a/src/test/fixtures/logs/image_output.log
+++ b/src/test/fixtures/logs/image_output.log
@@ -1,0 +1,7 @@
+                    INFO                                scene_file_writer.py:737
+                             File ready at
+                             '/proj/media/images/main/T
+                             estScene_ManimCE_v0.19.0.p
+                             ng'
+
+                    INFO     Rendered TestScene                   scene.py:247

--- a/src/test/fixtures/logs/partials_then_final.log
+++ b/src/test/fixtures/logs/partials_then_final.log
@@ -1,0 +1,5 @@
+INFO     File ready at '/proj/media/videos/main/1080p60/partial_movie_files/FullScene/uncached_00000.mp4'
+INFO     File ready at '/proj/media/videos/main/1080p60/partial_movie_files/FullScene/uncached_00001.mp4'
+INFO     Combining to Movie file.
+INFO     File ready at '/proj/media/videos/main/1080p60/FullScene.mp4'
+INFO     Rendered FullScene

--- a/src/test/fixtures/logs/wrapped_video.log
+++ b/src/test/fixtures/logs/wrapped_video.log
@@ -1,0 +1,9 @@
+                    INFO     Combining to Movie file.   scene_file_writer.py:617
+                    INFO                                scene_file_writer.py:737
+                             File ready at
+                             '/home/amran/dev/python/ma
+                             nimcs/media/videos/demo/48
+                             0p15/Demo.mp4'
+
+                    INFO     Rendered Demo                        scene.py:247
+                             Played 3 animations

--- a/src/test/fixtures/scenes/image_scene.py
+++ b/src/test/fixtures/scenes/image_scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class ImageScene(Scene):
+    def construct(self):
+        self.add(Circle())

--- a/src/test/fixtures/scenes/video_scene.py
+++ b/src/test/fixtures/scenes/video_scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class VideoScene(Scene):
+    def construct(self):
+        self.play(Create(Circle()), run_time=0.5)

--- a/src/test/unit/mediaResolution.test.ts
+++ b/src/test/unit/mediaResolution.test.ts
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  parseMediaOutputFromLog,
+  probeMediaOnDisk,
+  baseName,
+} from "../../mediaResolution";
+
+const FIXTURES = path.join(__dirname, "..", "..", "..", "src", "test", "fixtures");
+
+function loadLog(name: string): string {
+  return fs.readFileSync(path.join(FIXTURES, "logs", name), "utf-8");
+}
+
+test("parses a single-line File ready entry", () => {
+  const result = parseMediaOutputFromLog(
+    "INFO  File ready at '/proj/media/videos/main/720p30/Demo.mp4'"
+  );
+  assert.ok(result);
+  assert.strictEqual(result.isImage, false);
+  assert.strictEqual(result.mediaPath, "/proj/media/videos/main/720p30/Demo.mp4");
+});
+
+test("recovers a path wrapped across log lines (issue #132 shape)", () => {
+  // manim's rich console wraps long paths; whitespace inside the quotes
+  // must be stripped to recover the real path
+  const result = parseMediaOutputFromLog(loadLog("wrapped_video.log"));
+  assert.ok(result);
+  assert.strictEqual(result.isImage, false);
+  assert.strictEqual(
+    result.mediaPath,
+    "/home/amran/dev/python/manimcs/media/videos/demo/480p15/Demo.mp4"
+  );
+});
+
+test("prefers the merged output over partial movie files", () => {
+  const result = parseMediaOutputFromLog(loadLog("partials_then_final.log"));
+  assert.ok(result);
+  assert.strictEqual(result.isImage, false);
+  assert.strictEqual(
+    result.mediaPath,
+    "/proj/media/videos/main/1080p60/FullScene.mp4"
+  );
+});
+
+test("detects an image output (issue #139 logged case)", () => {
+  const result = parseMediaOutputFromLog(loadLog("image_output.log"));
+  assert.ok(result);
+  assert.strictEqual(result.isImage, true);
+  assert.strictEqual(
+    result.mediaPath,
+    "/proj/media/images/main/TestScene_ManimCE_v0.19.0.png"
+  );
+  assert.strictEqual(
+    baseName(result.mediaPath),
+    "TestScene_ManimCE_v0.19.0.png"
+  );
+});
+
+test("returns null when the log has no File ready entries", () => {
+  assert.strictEqual(
+    parseMediaOutputFromLog("Manim Community v0.19.0\nRendered TestScene\n"),
+    null
+  );
+});
+
+// ---- disk probe fallback (verbosity WARNING/ERROR, issue #139) ----
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "msv-test-"));
+}
+
+test("probe: image-only render is detected as an image", () => {
+  const dir = tmpdir();
+  const video = path.join(dir, "videos", "Scene.mp4");
+  const image = path.join(dir, "images", "Scene.png");
+  fs.mkdirSync(path.dirname(image), { recursive: true });
+  fs.writeFileSync(image, "png");
+
+  const result = probeMediaOnDisk(video, image);
+  assert.ok(result);
+  assert.strictEqual(result.isImage, true);
+  assert.strictEqual(result.mediaPath, image);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("probe: fresh image beats a stale video (issue #139 regression)", () => {
+  const dir = tmpdir();
+  const video = path.join(dir, "Scene.mp4");
+  const image = path.join(dir, "Scene.png");
+  fs.writeFileSync(video, "mp4");
+  fs.writeFileSync(image, "png");
+  const past = new Date(Date.now() - 3600 * 1000);
+  fs.utimesSync(video, past, past);
+
+  const result = probeMediaOnDisk(video, image);
+  assert.ok(result);
+  assert.strictEqual(result.isImage, true);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("probe: fresh video beats a stale image", () => {
+  const dir = tmpdir();
+  const video = path.join(dir, "Scene.mp4");
+  const image = path.join(dir, "Scene.png");
+  fs.writeFileSync(image, "png");
+  fs.writeFileSync(video, "mp4");
+  const past = new Date(Date.now() - 3600 * 1000);
+  fs.utimesSync(image, past, past);
+
+  const result = probeMediaOnDisk(video, image);
+  assert.ok(result);
+  assert.strictEqual(result.isImage, false);
+  assert.strictEqual(result.mediaPath, video);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("probe: returns null when neither predicted file exists", () => {
+  const dir = tmpdir();
+  assert.strictEqual(
+    probeMediaOnDisk(path.join(dir, "a.mp4"), path.join(dir, "b.png")),
+    null
+  );
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/src/test/unit/outputPaths.test.ts
+++ b/src/test/unit/outputPaths.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Tests globals.ts path prediction. globals.ts imports "vscode", which does
+ * not exist outside the editor, so a minimal stub is registered in the
+ * module cache before the import.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const Module = require("module");
+
+const settings: { [key: string]: unknown } = {};
+const vscodeStub = {
+  window: {
+    createOutputChannel: () => ({ appendLine: () => undefined }),
+    showErrorMessage: () => undefined,
+    showWarningMessage: () => undefined,
+    showInformationMessage: () => undefined,
+  },
+  workspace: {
+    getConfiguration: () => ({ get: (k: string) => settings[k] }),
+  },
+  Uri: {
+    joinPath: (base: { fsPath: string }, ...parts: string[]) => ({
+      fsPath: path.join(base.fsPath, ...parts),
+    }),
+    file: (p: string) => ({ fsPath: p }),
+  },
+};
+
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function (request: string, ...args: unknown[]) {
+  if (request === "vscode") {
+    return "vscode";
+  }
+  return originalResolve.call(this, request, ...args);
+};
+require.cache["vscode"] = {
+  id: "vscode",
+  filename: "vscode",
+  loaded: true,
+  exports: vscodeStub,
+} as never;
+
+const globals = require("../../globals");
+
+// load the real fallback configuration exactly as loadGlobals does
+const REPO = path.join(__dirname, "..", "..", "..");
+const cfgMap = JSON.parse(
+  fs.readFileSync(path.join(REPO, "assets", "local", "manim.cfg.json"), "utf-8")
+);
+globals.updateFallbackManimCfg(cfgMap, false);
+
+type Overrides = { [key: string]: string };
+
+function mkConfig(manimConfig: Overrides = {}, rest: Overrides = {}) {
+  return {
+    srcPath: rest.srcPath ?? "/proj/main.py",
+    sceneName: rest.sceneName ?? "Demo",
+    moduleName: rest.moduleName ?? "main",
+    srcRootFolder: rest.srcRootFolder ?? "/proj",
+    document: null,
+    isUsingConfFile: false,
+    manimConfig: { ...globals.getDefaultConfig(), ...manimConfig },
+  };
+}
+
+test("default config predicts the 1080p60 video path", () => {
+  assert.strictEqual(
+    globals.getVideoOutputPath(mkConfig()),
+    path.join("media", "videos", "main", "1080p60", "Demo.mp4")
+  );
+});
+
+test("quality names map to their quality folders", () => {
+  const cases: [string, string][] = [
+    ["low_quality", "480p15"],
+    ["medium_quality", "720p30"],
+    ["high_quality", "1080p60"],
+    ["production_quality", "1440p60"],
+    ["fourk_quality", "2160p60"],
+  ];
+  for (const [quality, folder] of cases) {
+    assert.strictEqual(
+      globals.getVideoOutputPath(mkConfig({ quality })),
+      path.join("media", "videos", "main", folder, "Demo.mp4")
+    );
+  }
+});
+
+test("explicit pixel dimensions override the quality folder (issue #115 cfg case)", () => {
+  const config = mkConfig({
+    pixel_width: "1080",
+    pixel_height: "1920",
+    frame_rate: "60",
+  });
+  assert.strictEqual(
+    globals.getVideoOutputPath(config),
+    path.join("media", "videos", "main", "1920p60", "Demo.mp4")
+  );
+});
+
+test("an unknown quality value throws (issue #137 pre-trim behavior)", () => {
+  assert.throws(() => {
+    globals.getVideoOutputPath(mkConfig({ quality: "low_quality " }));
+  });
+});
+
+test("image path uses the configured manim version (issue #139 fallback)", () => {
+  settings["manimExecutableVersion"] = "v0.19.0";
+  assert.strictEqual(
+    globals.getImageOutputPath(mkConfig(), undefined, ".png"),
+    path.join("media", "images", "main", "Demo_ManimCE_v0.19.0.png")
+  );
+});


### PR DESCRIPTION
Prepares the 0.4.0 release: ships the path-resolution and environment-discovery overhaul already on master, plus three new fixes, a changelog, and the version bump.

## New fixes

- **#137** - `manim.cfg` values are trimmed, so trailing whitespace like `quality = low_quality ` no longer fails the render
- **#98** - the interpreter's bin directory is prepended to the spawned process `PATH`, so ffmpeg installed inside a conda/venv environment is found even when it is not on the global PATH; also applies when `defaultManimPath` is an absolute path into an env
- `manimExecutableVersion` default bumped `v0.16.0.post0` -> `v0.19.0` so fallback image-name prediction matches current manim (hardens #139 when verbosity hides logs)

## Release chore

- `CHANGELOG.md` covering everything since 0.3.1, grouped by theme with issue references
- version 0.3.1 -> 0.4.0

## Verification

Logic-level verification replayed each issue's real log/config data through the actual compiled resolution code:

| Issue | Check | Result |
|---|---|---|
| #132 | real 480p15 log line resolves to 480p15, not the static 1080p60 recompute | pass |
| #115 | in-file `config.pixel_*` custom-resolution path resolved from log | pass |
| #99 | `-qm` via `commandLineArgs` resolves to 720p30 folder | pass |
| #139 | log-silent fallback picks image; stale video + fresh image -> image wins | pass |
| #127/#133 | `Scripts` directory gets executable name appended | pass |
| #137 | trailing-space quality reproduced pre-fix, resolved post-fix | pass |

tsc, eslint (one pre-existing warning untouched), webpack dev and production vsix builds all pass.

## Live-render checklist (Extension Development Host)

- [ ] `commandLineArgs = "-ql"`: renders and previews 480p15 without a predicted-path error (#132/#99)
- [ ] scene with `config.pixel_width/height` in-file previews correctly (#115)
- [ ] `verbosity = WARNING` + animation-less scene previews the image (#139)
- [ ] `quality = low_quality ` (trailing space) in manim.cfg renders normally (#137)
- [ ] conda env with local ffmpeg: no pydub ffmpeg warning, render completes (#98)
- [ ] windows: `defaultManimPath` set to a `Scripts` directory resolves manim.exe (#127/#133)
