### PR TITLE
Change RE_SCENE_CLASS regex to better identify Scene classes

### DIFF
--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -36,7 +36,7 @@ const RELEVANT_CONFIG_OPTIONS = [
   "video_dir",
   "images_dir",
 ];
-const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*\bScene\b[\w,\s]*\):/g;
+const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*Scene\b[\w,\s]*\):/g;
 const RE_CFG_OPTIONS = /(\w+)\s?:\s?([^ ]*)/g;
 const RE_FILE_READY = /File\s*ready\s*at[^']*'(?<path>[^']*)'/g;
 

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -36,7 +36,7 @@ const RELEVANT_CONFIG_OPTIONS = [
   "video_dir",
   "images_dir",
 ];
-const RE_SCENE_CLASS = /class\s+(?<name>\w+)\(\w*Scene\w*\):/g;
+const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*\bScene\b[\w,\s]*\):/g;
 const RE_CFG_OPTIONS = /(\w+)\s?:\s?([^ ]*)/g;
 const RE_FILE_READY = /File\s*ready\s*at[^']*'(?<path>[^']*)'/g;
 


### PR DESCRIPTION
while using [manim-slides](https://www.manim.community/plugin/manim-slides/) I noticed that the regex we use to identify scene classes is problematic.

Current logic
[X] `class MyClass(Slide, Scene):`
[V] `class test(SceneWTF):`

Suggested logic:
[X] `class test(Slide, SceneWTF):`
[V] `class test(Slide, Scene):`
[V] `class test(Scene, Slide):`
[V] `class test(Slide, MovingCameraScene):`
[V] `class test(Scene,Slide):`
[V] `class test(Slide,Scene): `
[V] `class test(Slide,MovingCameraScene):`
[V] `class test(MovingCameraScene):`
[V] `class test(Slide, manim.Scene):`

Extension was built and tested locally after change.
Extra suggestion and request are very welcome.
Thanks you :)