### PR TITLE
Fix loop setting persistence on reload

### DIFF
--- a/webview/player/player.js
+++ b/webview/player/player.js
@@ -395,7 +395,6 @@ window.addEventListener("message", (e) => {
         // but explicitly calling play ensures it tries if allowed.
         video.play().catch((err) => console.log("Autoplay prevented:", err)); // Play new video (browser might block)
         // Reset state for new video
-        video.loop = message.loop; // Assuming loop state comes from extension
         setPlaybackSpeed(1); // Reset speed
         updatePlayPauseIcon();
         updateVolumeIcon();


### PR DESCRIPTION
When a file is saved, the video player loop is closed. This pull request fix that.
