### PR TITLE
fix: activate conda-style environments when spawning manim

### DIFF
--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -78,6 +78,63 @@ function quoteSpecialChars(text: string): string {
   return text;
 }
 
+/**
+ * Builds the environment for spawning manim from a conda-style environment
+ * (conda, mamba, micromamba, pixi).
+ *
+ * Such environments are not self-contained on Windows: native libraries live
+ * in directories (e.g. `<prefix>\Library\bin`) that only join PATH during
+ * activation. Spawning the bare executable without activation crashes the
+ * process at the OS loader level (exit code 0xC06D007F) with no traceback the
+ * moment a delay-loaded DLL such as numpy's BLAS is first called.
+ *
+ * Prepending the activation directories to PATH is sufficient to fix DLL
+ * resolution; `conda-meta` at the prefix root is the marker all conda-style
+ * managers share.
+ *
+ * @param manimExe absolute path to the manim executable being spawned
+ * @returns an environment with activation paths injected, or undefined to
+ * inherit the parent environment untouched (non-conda installs)
+ */
+function getActivationEnvironment(
+  manimExe: string
+): NodeJS.ProcessEnv | undefined {
+  if (!path.isAbsolute(manimExe)) {
+    return undefined;
+  }
+  // <prefix>/Scripts/manim.exe (win32) or <prefix>/bin/manim (unix)
+  const prefix = path.dirname(path.dirname(manimExe));
+  if (!fs.existsSync(path.join(prefix, "conda-meta"))) {
+    return undefined;
+  }
+
+  // The same directories conda activation prepends to PATH, in its order.
+  const binDirs =
+    process.platform === "win32"
+      ? [
+          prefix,
+          path.join(prefix, "Library", "mingw-w64", "bin"),
+          path.join(prefix, "Library", "usr", "bin"),
+          path.join(prefix, "Library", "bin"),
+          path.join(prefix, "Scripts"),
+          path.join(prefix, "bin"),
+        ]
+      : [path.join(prefix, "bin")];
+
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  // On Windows the inherited key may be spelled "Path"; reuse it to avoid
+  // handing the child duplicate PATH variables differing only in case.
+  const pathKey =
+    Object.keys(env).find((key) => key.toUpperCase() === "PATH") || "PATH";
+  env[pathKey] =
+    binDirs.join(path.delimiter) + path.delimiter + (env[pathKey] || "");
+  env.CONDA_PREFIX = prefix;
+  Log.info(
+    `Detected conda-style environment at "${prefix}"; spawning manim with activation paths injected.`
+  );
+  return env;
+}
+
 export class ManimSideview {
   constructor(
     public readonly ctx: vscode.ExtensionContext,
@@ -423,7 +480,10 @@ export class ManimSideview {
         "Manim Sideview: Preparing to sync fallback manim configurations..."
       )
     );
-    const process = spawn((await this.getManimPath()).manim, ["cfg", "show"]);
+    const manimPath = (await this.getManimPath()).manim;
+    const process = spawn(manimPath, ["cfg", "show"], {
+      env: getActivationEnvironment(manimPath),
+    });
 
     let fullStdout = "";
     process.stdout.on("data", function (data: string) {
@@ -656,7 +716,11 @@ export class ManimSideview {
     onProcessClose: (m: MediaInfo) => void
   ) {
     const startTime = new Date();
-    const process = spawn(command, args, { cwd: cwd, shell: false });
+    const process = spawn(command, args, {
+      cwd: cwd,
+      shell: false,
+      env: getActivationEnvironment(command),
+    });
     const job = this.jobManager.getActiveJob(srcPath);
 
     // String representation of the command process


### PR DESCRIPTION
## Problem

Rendering from the extension fails instantly for users whose manim lives in a conda-style environment (conda, mamba, micromamba, **pixi**), with no traceback:

```
ERROR: Manim Sideview: Error rendering file (exit code 3228369023).
```

`3228369023` = `0xC06D007F`, the Windows VC++ delay-load failure — the process is killed by the OS loader before Python can raise anything. The same command works from the user's terminal, which makes it look like a user-side problem. It isn't.

## Cause

The extension spawns the resolved `manim.exe` directly with an inherited (un-activated) environment. Conda-style prefixes are not self-contained on Windows: native libraries live in `<prefix>\Library\bin`, which only joins `PATH` during activation.

conda Python papers over most of this by registering `Library\bin` as a DLL directory at startup — which is why imports, cairo rendering, and video muxing all work un-activated. The exception is **delay-loaded** DLLs: conda-forge numpy delay-loads its BLAS (`libcblas.dll` in `_multiarray_umath.pyd`'s delay-import table), and delay-load resolution goes through a plain `LoadLibrary` that only honors `PATH`. The first real matrix multiplication crashes the process.

In manim that first matmul is the bezier remap inside `Transform.begin()` — so scenes with only e.g. `GrowFromCenter` render fine while any scene containing a `Transform` or `Write(Text(...))` dies, which made the failures look nondeterministic.

Minimal repro inside such an env, un-activated:

```python
import numpy as np
a = np.ones((3, 3))
a @ a   # exit 0xC06D007F
```

## Fix

`getActivationEnvironment()` detects a conda-style prefix by its `conda-meta` directory (the marker shared by all conda-family managers) and prepends the standard activation directories to `PATH` for the spawned process, mirroring what `conda activate` / `pixi shell` do. Applied to both spawn sites (render and `cfg show`).

Non-conda installs return `undefined` and inherit the parent environment exactly as before.

## Verification

Reproduced with a pixi env built from an affected user's exact manifest (`manim >=0.20.1,<0.21`, python 3.13, pyqt6, manim-slides), on Windows 11:

| Spawn | Result |
|---|---|
| current behavior (inherited env) | exit `0xC06D007F` |
| `pixi run manim ...` (control) | exit 0 |
| patched behavior (activation PATH injected) | exit 0 |

Detection checks: conda-style exe → env injected; plain venv exe and bare `manim` → `undefined` (unchanged behavior). `npm run compile` and `npm run lint` pass.

## Notes

- Possible follow-up: special-case `0xC06D00xx` exit codes in the error message, since these crashes produce no stderr to "check the output" for.
- Not included: `QT_PLUGIN_PATH` injection (full activation also sets it; could matter for manim-slides/pyqt6 users, but out of scope for this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
