### PR TITLE
test: harden coverage before 0.4.0 publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,37 @@ jobs:
       - run: npm run compile
       - run: npm run test:unit
 
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      # proves the production webpack bundle builds and packs into a vsix
+      - run: npx @vscode/vsce package --out manim-sideview.vsix
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vsix
+          path: manim-sideview.vsix
+
   contract:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # power users pin old manim versions; the log format the extension
+          # parses must hold across all of them
+          - manim: "manim==0.17.3"
+            python: "3.11"
+          - manim: "manim==0.18.1"
+            python: "3.11"
+          - manim: "manim>=0.19"
+            python: "3.12"
+    name: contract (${{ matrix.manim }})
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -29,9 +58,9 @@ jobs:
           cache: npm
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python }}
       - run: npm ci
       # manimpango has no linux wheels; it builds against pango headers
       - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config
-      - run: pip install "manim>=0.19"
+      - run: pip install "${{ matrix.manim }}"
       - run: npm run test:contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: npm ci
-      # manimpango has no linux wheels; it builds against pango headers
-      - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config
+      # manimpango has no linux wheels; it builds against pango headers.
+      # ffmpeg is needed by manim <= 0.18, which shells out to it (0.19+
+      # bundles pyav)
+      - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config ffmpeg
       - run: pip install "${{ matrix.manim }}"
       - run: npm run test:contract

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -179,5 +179,55 @@ function check(name, fn) {
   fs.rmSync(cwd, { recursive: true, force: true });
 }
 
+// 5. custom media_dir + silent logs: the disk probe must respect media_dir
+{
+  const cwd = freshDir("mediadir");
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "custom_media_dir", "scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "custom_media_dir", "manim.cfg"),
+    path.join(cwd, "manim.cfg")
+  );
+  const render = run(["-ql", "scene.py", "ImageScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("custom media_dir: render succeeds with silent logs", () => {
+    assert.strictEqual(render.status, 0, `manim exited ${render.status}:\n${logbook}`);
+    assert.strictEqual(parseMediaOutputFromLog(logbook), null);
+  });
+
+  check("custom media_dir: disk probe finds the image under out_custom", () => {
+    const versionTag = (version.stdout.trim() || version.stderr.trim())
+      .match(/v\d+(\.\d+)*(\.post\d+)?/)?.[0];
+    assert.ok(versionTag, "could not parse manim version");
+    const predictedImage = path.join(
+      cwd,
+      "out_custom",
+      "images",
+      "scene",
+      `ImageScene_ManimCE_${versionTag}.png`
+    );
+    const predictedVideo = path.join(
+      cwd,
+      "out_custom",
+      "videos",
+      "scene",
+      "480p15",
+      "ImageScene.mp4"
+    );
+    const probed = probeMediaOnDisk(predictedVideo, predictedImage);
+    assert.ok(
+      probed,
+      `probe found nothing; tree: ${JSON.stringify(
+        fs.readdirSync(cwd, { recursive: true })
+      )}`
+    );
+    assert.strictEqual(probed.isImage, true);
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
 console.log(failures === 0 ? "\nCONTRACT TESTS PASSED" : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -30,6 +30,7 @@ import {
   probeMediaOnDisk,
   baseName,
 } from "./mediaResolution";
+import { buildSpawnEnv } from "./spawnEnv";
 
 const CONFIG_SECTION = "CLI";
 const RELEVANT_CONFIG_OPTIONS = [
@@ -84,75 +85,19 @@ function quoteSpecialChars(text: string): string {
 }
 
 /**
- * Builds the environment for spawning manim from a conda-style environment
- * (conda, mamba, micromamba, pixi).
- *
- * Such environments are not self-contained on Windows: native libraries live
- * in directories (e.g. `<prefix>\Library\bin`) that only join PATH during
- * activation. Spawning the bare executable without activation crashes the
- * process at the OS loader level (exit code 0xC06D007F) with no traceback the
- * moment a delay-loaded DLL such as numpy's BLAS is first called.
- *
- * Prepending the activation directories to PATH is sufficient to fix DLL
- * resolution; `conda-meta` at the prefix root is the marker all conda-style
- * managers share.
- *
- * For non-conda installs, falls back to prepending the interpreter's bin
- * directory when one is known, so tools installed next to manim (ffmpeg in
- * venv environments) are found (#98).
- *
- * @param manimExe absolute path to the manim executable being spawned
- * @param binDir the interpreter's bin directory, if known
- * @returns an environment with the needed paths injected, or undefined to
- * inherit the parent environment untouched
+ * Wraps the pure spawn-env builder (see spawnEnv.ts) with logging.
  */
 function getActivationEnvironment(
   manimExe: string,
   binDir?: string
 ): NodeJS.ProcessEnv | undefined {
-  let prefix: string | undefined;
-  if (path.isAbsolute(manimExe)) {
-    // <prefix>/Scripts/manim.exe (win32) or <prefix>/bin/manim (unix)
-    const candidate = path.dirname(path.dirname(manimExe));
-    if (fs.existsSync(path.join(candidate, "conda-meta"))) {
-      prefix = candidate;
-    }
-  }
-
-  let binDirs: string[];
-  if (prefix) {
-    // The same directories conda activation prepends to PATH, in its order.
-    binDirs =
-      process.platform === "win32"
-        ? [
-            prefix,
-            path.join(prefix, "Library", "mingw-w64", "bin"),
-            path.join(prefix, "Library", "usr", "bin"),
-            path.join(prefix, "Library", "bin"),
-            path.join(prefix, "Scripts"),
-            path.join(prefix, "bin"),
-          ]
-        : [path.join(prefix, "bin")];
-  } else if (binDir) {
-    binDirs = [binDir];
-  } else {
-    return undefined;
-  }
-
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  // On Windows the inherited key may be spelled "Path"; reuse it to avoid
-  // handing the child duplicate PATH variables differing only in case.
-  const pathKey =
-    Object.keys(env).find((key) => key.toUpperCase() === "PATH") || "PATH";
-  env[pathKey] =
-    binDirs.join(path.delimiter) + path.delimiter + (env[pathKey] || "");
-  if (prefix) {
-    env.CONDA_PREFIX = prefix;
+  const built = buildSpawnEnv(manimExe, binDir);
+  if (built?.condaPrefix) {
     Log.info(
-      `Detected conda-style environment at "${prefix}"; spawning manim with activation paths injected.`
+      `Detected conda-style environment at "${built.condaPrefix}"; spawning manim with activation paths injected.`
     );
   }
-  return env;
+  return built?.env;
 }
 
 export class ManimSideview {

--- a/src/spawnEnv.ts
+++ b/src/spawnEnv.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Pure builder for the environment used when spawning manim. Kept free of
+ * any vscode dependency so it can be unit tested directly; dependencies on
+ * the platform, parent environment, and filesystem are injectable.
+ *
+ * Conda-style environments (conda, mamba, micromamba, pixi) are not
+ * self-contained on Windows: native libraries live in directories (e.g.
+ * `<prefix>\Library\bin`) that only join PATH during activation. Spawning
+ * the bare executable without activation crashes the process at the OS
+ * loader level (exit code 0xC06D007F) with no traceback the moment a
+ * delay-loaded DLL such as numpy's BLAS is first called. Prepending the
+ * activation directories to PATH fixes DLL resolution; `conda-meta` at the
+ * prefix root is the marker all conda-style managers share.
+ *
+ * For non-conda installs, falls back to prepending the interpreter's bin
+ * directory when one is known, so tools installed next to manim (ffmpeg in
+ * venv environments) are found (#98).
+ */
+
+export type SpawnEnvDeps = {
+  platform: NodeJS.Platform;
+  baseEnv: NodeJS.ProcessEnv;
+  exists: (p: string) => boolean;
+};
+
+export type SpawnEnvResult = {
+  env: NodeJS.ProcessEnv;
+  condaPrefix?: string;
+};
+
+const defaultDeps = (): SpawnEnvDeps => ({
+  platform: process.platform,
+  baseEnv: process.env,
+  exists: fs.existsSync,
+});
+
+/**
+ * @param manimExe path to the manim executable being spawned
+ * @param binDir the interpreter's bin directory, if known
+ * @returns the environment to spawn with, or undefined to inherit the
+ * parent environment untouched
+ */
+export function buildSpawnEnv(
+  manimExe: string,
+  binDir?: string,
+  deps: SpawnEnvDeps = defaultDeps()
+): SpawnEnvResult | undefined {
+  let prefix: string | undefined;
+  if (path.isAbsolute(manimExe)) {
+    // <prefix>/Scripts/manim.exe (win32) or <prefix>/bin/manim (unix)
+    const candidate = path.dirname(path.dirname(manimExe));
+    if (deps.exists(path.join(candidate, "conda-meta"))) {
+      prefix = candidate;
+    }
+  }
+
+  let binDirs: string[];
+  if (prefix) {
+    // The same directories conda activation prepends to PATH, in its order.
+    binDirs =
+      deps.platform === "win32"
+        ? [
+            prefix,
+            path.join(prefix, "Library", "mingw-w64", "bin"),
+            path.join(prefix, "Library", "usr", "bin"),
+            path.join(prefix, "Library", "bin"),
+            path.join(prefix, "Scripts"),
+            path.join(prefix, "bin"),
+          ]
+        : [path.join(prefix, "bin")];
+  } else if (binDir) {
+    binDirs = [binDir];
+  } else {
+    return undefined;
+  }
+
+  const env: NodeJS.ProcessEnv = { ...deps.baseEnv };
+  // On Windows the inherited key may be spelled "Path"; reuse it to avoid
+  // handing the child duplicate PATH variables differing only in case.
+  const pathKey =
+    Object.keys(env).find((key) => key.toUpperCase() === "PATH") || "PATH";
+  env[pathKey] =
+    binDirs.join(path.delimiter) + path.delimiter + (env[pathKey] || "");
+  if (prefix) {
+    env.CONDA_PREFIX = prefix;
+  }
+  return { env, condaPrefix: prefix };
+}

--- a/src/test/fixtures/issues/custom_media_dir/manim.cfg
+++ b/src/test/fixtures/issues/custom_media_dir/manim.cfg
@@ -1,0 +1,3 @@
+[CLI]
+media_dir = out_custom
+verbosity = WARNING

--- a/src/test/fixtures/issues/custom_media_dir/scene.py
+++ b/src/test/fixtures/issues/custom_media_dir/scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class ImageScene(Scene):
+    def construct(self):
+        self.add(Circle())

--- a/src/test/unit/outputPaths.test.ts
+++ b/src/test/unit/outputPaths.test.ts
@@ -109,6 +109,19 @@ test("an unknown quality value throws (issue #137 pre-trim behavior)", () => {
   });
 });
 
+test("custom media_dir is honored in both predicted paths", () => {
+  settings["manimExecutableVersion"] = "v0.19.0";
+  const config = mkConfig({ media_dir: "out_custom" });
+  assert.strictEqual(
+    globals.getVideoOutputPath(config),
+    path.join("out_custom", "videos", "main", "1080p60", "Demo.mp4")
+  );
+  assert.strictEqual(
+    globals.getImageOutputPath(config, undefined, ".png"),
+    path.join("out_custom", "images", "main", "Demo_ManimCE_v0.19.0.png")
+  );
+});
+
 test("image path uses the configured manim version (issue #139 fallback)", () => {
   settings["manimExecutableVersion"] = "v0.19.0";
   assert.strictEqual(

--- a/src/test/unit/spawnEnv.test.ts
+++ b/src/test/unit/spawnEnv.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import * as assert from "assert";
+import * as path from "path";
+
+import { buildSpawnEnv, SpawnEnvDeps } from "../../spawnEnv";
+
+function deps(overrides: Partial<SpawnEnvDeps> = {}): SpawnEnvDeps {
+  return {
+    platform: "linux",
+    baseEnv: { PATH: "/usr/bin" },
+    exists: () => false,
+    ...overrides,
+  };
+}
+
+test("relative command inherits the parent environment", () => {
+  assert.strictEqual(buildSpawnEnv("manim", undefined, deps()), undefined);
+});
+
+test("absolute non-conda path without binDir inherits the parent environment", () => {
+  assert.strictEqual(
+    buildSpawnEnv("/opt/tools/bin/manim", undefined, deps()),
+    undefined
+  );
+});
+
+test("venv fallback prepends the interpreter bin dir (#98)", () => {
+  const result = buildSpawnEnv(
+    "/proj/.venv/bin/manim",
+    "/proj/.venv/bin",
+    deps()
+  );
+  assert.ok(result);
+  assert.strictEqual(result.condaPrefix, undefined);
+  assert.strictEqual(
+    result.env.PATH,
+    `/proj/.venv/bin${path.delimiter}/usr/bin`
+  );
+});
+
+test("conda prefix on linux prepends its bin and sets CONDA_PREFIX", () => {
+  const prefix = "/home/u/miniconda3/envs/anim";
+  const result = buildSpawnEnv(`${prefix}/bin/manim`, undefined, deps({
+    exists: (p) => p === path.join(prefix, "conda-meta"),
+  }));
+  assert.ok(result);
+  assert.strictEqual(result.condaPrefix, prefix);
+  assert.strictEqual(result.env.CONDA_PREFIX, prefix);
+  assert.strictEqual(
+    result.env.PATH,
+    `${path.join(prefix, "bin")}${path.delimiter}/usr/bin`
+  );
+});
+
+// note: prefix is posix-style because the ambient path module on the test
+// host decides absoluteness; platform only selects the activation dir list
+test("conda prefix on win32 prepends the full activation dir list in order", () => {
+  const prefix = path.join(path.sep, "envs", "anim");
+  const result = buildSpawnEnv(
+    path.join(prefix, "Scripts", "manim.exe"),
+    undefined,
+    deps({
+      platform: "win32",
+      baseEnv: { Path: "C:\\Windows\\system32" },
+      exists: (p) => p === path.join(prefix, "conda-meta"),
+    })
+  );
+  assert.ok(result);
+  const expected = [
+    prefix,
+    path.join(prefix, "Library", "mingw-w64", "bin"),
+    path.join(prefix, "Library", "usr", "bin"),
+    path.join(prefix, "Library", "bin"),
+    path.join(prefix, "Scripts"),
+    path.join(prefix, "bin"),
+  ].join(path.delimiter);
+  // the inherited "Path" spelling must be reused, not duplicated as "PATH"
+  assert.strictEqual(result.env.Path, `${expected}${path.delimiter}C:\\Windows\\system32`);
+  assert.strictEqual(
+    Object.keys(result.env).filter((k) => k.toUpperCase() === "PATH").length,
+    1
+  );
+  assert.strictEqual(result.env.CONDA_PREFIX, prefix);
+});
+
+test("conda detection wins over the binDir fallback", () => {
+  const prefix = "/envs/anim";
+  const result = buildSpawnEnv(`${prefix}/bin/manim`, `${prefix}/bin`, deps({
+    exists: (p) => p === path.join(prefix, "conda-meta"),
+  }));
+  assert.ok(result);
+  assert.strictEqual(result.condaPrefix, prefix);
+});
+
+test("missing parent PATH still produces a usable PATH", () => {
+  const result = buildSpawnEnv("/v/bin/manim", "/v/bin", deps({ baseEnv: {} }));
+  assert.ok(result);
+  assert.strictEqual(result.env.PATH, `/v/bin${path.delimiter}`);
+});


### PR DESCRIPTION
Pre-publish hardening from the release test-gap review.

- Extracts the spawn environment builder (conda activation + venv binDir fallback) into a pure, dependency-injected module (src/spawnEnv.ts) and adds unit tests covering conda detection on both platforms, the venv fallback, the Windows Path/PATH key reuse, and inherit-parent cases.
- Adds custom media_dir coverage: unit tests for predicted paths and a contract case combining media_dir with silent logs (the disk-probe fallback path).
- CI: contract tests now run as a matrix over manim 0.17.3 / 0.18.1 / >=0.19 to catch log-format drift for users pinning old versions, and a package job builds the production vsix and uploads it as an artifact.

Local: lint clean (one pre-existing warning), 22/22 unit tests pass, vsix packages at 2.34 MB.

Not covered here (needs a Windows machine): live conda/venv/Scripts-dir render smoke.