### PR TITLE
feat: opt-in run from workspace root

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -25,8 +25,9 @@ binary with `MANIM_BIN=/path/to/manim`) in a temp directory and feeds the
 live output through the extension's actual resolution code. This catches
 drift in manim's "File ready at" log format, which path prediction relies
 on. Cases: video render with `-ql`, image render, silent logs under
-`verbosity = WARNING` (disk probe), and a `manim.cfg` with trailing
-whitespace in the quality value.
+`verbosity = WARNING` (disk probe), a `manim.cfg` with trailing
+whitespace in the quality value, and a subfolder scene rendered from the
+project root with a root-level `manim.cfg` (run-from-workspace-root).
 
 ## 3. Manual checks (Extension Development Host)
 
@@ -39,6 +40,7 @@ listed per row. All fixtures render in under a minute at low quality.
 | In-file resolution override (#115) | Open `src/test/fixtures/issues/115_custom_resolution/`, render `scene.py` scene `VerticalScene` | 1080x1920 video previews |
 | Silent logs, image output (#139) | Open `src/test/fixtures/issues/139_low_verbosity/`, render `scene.py` scene `ImageScene`; set `manim-sideview.manimExecutableVersion` to your manim version if not v0.19.0 | image previews, no stale-video preview, no error |
 | Trailing whitespace in cfg (#137) | Open `src/test/fixtures/issues/137_trailing_space/`, render `scene.py` scene `VideoScene` | renders normally, no "quality is invalid" error |
+| Run from workspace root | Open `src/test/fixtures/issues/workspace_root_run/` as the workspace folder, enable `manim-sideview.runFromWorkspaceRoot`, render `src/scene.py` scene `ImageScene`; set `manim-sideview.manimExecutableVersion` to your manim version if not v0.19.0 | root `manim.cfg` is picked up, image lands in `out_root/` at the workspace root (not inside `src/`), preview works |
 | Env-local ffmpeg (#98) | conda or venv with ffmpeg installed inside it and not on the global PATH; set `manim-sideview.defaultManimPath` to that env's `bin/manim` | no pydub ffmpeg warning, render completes |
 | Scripts directory as manim path (#127, #133) | Windows: set `manim-sideview.defaultManimPath` to a `Scripts` directory containing manim.exe | manim resolved inside the directory, render runs |
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
           "default": "false",
           "description": "Enable or disable the automatic running of a previously run file upon saving."
         },
+        "manim-sideview.runFromWorkspaceRoot": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run Manim from the workspace folder containing the file instead of the file's own directory. A manim.cfg at the workspace root then applies to every scene, the media folder is generated at the root, and relative paths inside scenes resolve from the root."
+        },
         "manim-sideview.focusOutputOnRun": {
           "type": "boolean",
           "default": "true",

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -229,5 +229,64 @@ function check(name, fn) {
   fs.rmSync(cwd, { recursive: true, force: true });
 }
 
+// 6. run from workspace root: scene in a subfolder, root manim.cfg with a
+// custom media_dir and silent logs; the probe rooted at the project root
+// must find the output under the ROOT media dir, not the subfolder
+{
+  const cwd = freshDir("wsroot");
+  fs.mkdirSync(path.join(cwd, "src"));
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "workspace_root_run", "manim.cfg"),
+    path.join(cwd, "manim.cfg")
+  );
+  fs.copyFileSync(
+    path.join(FIXTURES, "issues", "workspace_root_run", "src", "scene.py"),
+    path.join(cwd, "src", "scene.py")
+  );
+  const render = run(["-ql", path.join("src", "scene.py"), "ImageScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("workspace root: render succeeds with silent logs", () => {
+    assert.strictEqual(render.status, 0, `manim exited ${render.status}:\n${logbook}`);
+    assert.strictEqual(parseMediaOutputFromLog(logbook), null);
+  });
+
+  check("workspace root: disk probe finds the image under the root media dir", () => {
+    const versionTag = (version.stdout.trim() || version.stderr.trim())
+      .match(/v\d+(\.\d+)*(\.post\d+)?/)?.[0];
+    assert.ok(versionTag, "could not parse manim version");
+    // predictions join srcRootFolder (= project root) with the media_dir
+    // template, mirroring how the extension probes when the feature is on
+    const predictedImage = path.join(
+      cwd,
+      "out_root",
+      "images",
+      "scene",
+      `ImageScene_ManimCE_${versionTag}.png`
+    );
+    const predictedVideo = path.join(
+      cwd,
+      "out_root",
+      "videos",
+      "scene",
+      "480p15",
+      "ImageScene.mp4"
+    );
+    const probed = probeMediaOnDisk(predictedVideo, predictedImage);
+    assert.ok(
+      probed,
+      `probe found nothing; tree: ${JSON.stringify(
+        fs.readdirSync(cwd, { recursive: true })
+      )}`
+    );
+    assert.strictEqual(probed.isImage, true);
+    assert.ok(
+      !fs.existsSync(path.join(cwd, "src", "out_root")),
+      "media dir leaked into the source subfolder"
+    );
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+}
+
 console.log(failures === 0 ? "\nCONTRACT TESTS PASSED" : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -79,6 +79,8 @@ export function getDefaultConfig() {
  * document: the vscode.TextDocument for the Python file
  * isUsingCfgFile: whether if this is running using a configuration file
  * manimConfig: manim config tied to the running config
+ * usesWorkspaceRoot: whether srcRootFolder is the workspace folder rather
+ * than the file's own directory (runFromWorkspaceRoot setting)
  */
 export type RunningConfig = {
   srcPath: string;
@@ -88,6 +90,7 @@ export type RunningConfig = {
   document: vscode.TextDocument;
   isUsingConfFile: boolean;
   manimConfig: ManimConfig;
+  usesWorkspaceRoot?: boolean;
 };
 
 export function getVideoOutputPath(

--- a/src/runRoot.ts
+++ b/src/runRoot.ts
@@ -1,0 +1,54 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Pure helpers for the opt-in "run from workspace root" feature. Kept free
+ * of any vscode dependency so they can be unit tested directly.
+ */
+
+/**
+ * Picks the manim.cfg path the run should use.
+ *
+ * An explicitly set config path always wins. Otherwise, when a workspace
+ * run root is active, a manim.cfg at that root is preferred because that is
+ * the cwd manim will read it from; if none exists there, fall back to the
+ * one next to the source file. Without a run root the choice is exactly the
+ * legacy next-to-file path.
+ */
+export function findManimConfigPath(
+  explicitPath: string,
+  srcfilePath: string,
+  runRoot?: string,
+  exists: (p: string) => boolean = fs.existsSync
+): string {
+  if (explicitPath) {
+    return explicitPath;
+  }
+  if (runRoot) {
+    const rootConfig = path.join(runRoot, "manim.cfg");
+    if (exists(rootConfig)) {
+      return rootConfig;
+    }
+  }
+  return path.join(srcfilePath, "../manim.cfg");
+}
+
+/**
+ * The scene file argument passed to manim. When running from the workspace
+ * root this is the path relative to that root, matching a manual
+ * `manim src/main.py` invocation; otherwise the absolute path as before.
+ */
+export function resolveSceneFileArg(
+  srcPath: string,
+  runRoot: string,
+  usesWorkspaceRoot: boolean
+): string {
+  if (!usesWorkspaceRoot) {
+    return srcPath;
+  }
+  const relative = path.relative(runRoot, srcPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return srcPath;
+  }
+  return relative;
+}

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -31,6 +31,7 @@ import {
   baseName,
 } from "./mediaResolution";
 import { buildSpawnEnv } from "./spawnEnv";
+import { findManimConfigPath, resolveSceneFileArg } from "./runRoot";
 
 const CONFIG_SECTION = "CLI";
 const RELEVANT_CONFIG_OPTIONS = [
@@ -172,8 +173,17 @@ export class ManimSideview {
       activeJob = this.jobManager.getActiveJob(document.fileName);
     }
 
+    // when enabled and the file sits inside a workspace folder, manim runs
+    // from that folder instead of the file's own directory
+    const workspaceRoot = getUserConfiguration<boolean>("runFromWorkspaceRoot")
+      ? vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath
+      : undefined;
+
     // configuration is reloaded every run
-    let manimConfig = await this.getManimConfigFile(document.uri.fsPath);
+    let manimConfig = await this.getManimConfigFile(
+      document.uri.fsPath,
+      workspaceRoot
+    );
     let isConfFile: boolean;
 
     if (manimConfig) {
@@ -197,6 +207,10 @@ export class ManimSideview {
       // if there is an active job simply resume
       activeJob.config.manimConfig = manimConfig;
       activeJob.config.isUsingConfFile = isConfFile;
+      // keep the run root in sync in case the setting changed between runs
+      activeJob.config.srcRootFolder =
+        workspaceRoot ?? path.dirname(document.uri.fsPath);
+      activeJob.config.usesWorkspaceRoot = !!workspaceRoot;
       currentRunningConfig = activeJob.config;
     } else {
       const newSceneName = await this.getRenderSceneName(document.uri);
@@ -211,7 +225,8 @@ export class ManimSideview {
         document,
         newSceneName,
         isConfFile,
-        manimConfig
+        manimConfig,
+        workspaceRoot
       );
     }
 
@@ -585,7 +600,7 @@ export class ManimSideview {
     this.jobManager.addJob(config, PlayableMediaType.Video);
 
     const args: string[] = [
-      config.srcPath,
+      resolveSceneFileArg(config.srcPath, cwd, !!config.usesWorkspaceRoot),
       ...(config.isUsingConfFile ? [] : this.getPreferenceArgs()),
       config.sceneName.trim(),
     ];
@@ -940,11 +955,14 @@ export class ManimSideview {
    * @returns ManimConfig | undefined
    */
   private async getManimConfigFile(
-    srcfilePath: string
+    srcfilePath: string,
+    runRoot?: string
   ): Promise<ManimConfig | undefined> {
-    const filePath = this.manimConfPath
-      ? this.manimConfPath
-      : path.join(srcfilePath, "../manim.cfg");
+    const filePath = findManimConfigPath(
+      this.manimConfPath,
+      srcfilePath,
+      runRoot
+    );
 
     if (!fs.existsSync(filePath)) {
       return;
@@ -1000,16 +1018,18 @@ export class ManimSideview {
     document: vscode.TextDocument,
     sceneName: string,
     isUsingCfgFile: boolean,
-    manimConfig: ManimConfig
+    manimConfig: ManimConfig,
+    workspaceRoot?: string
   ): RunningConfig {
     const srcPath = document.uri.fsPath;
     Log.info(`Creating a new running configuration for file "${srcPath}"`);
 
     const moduleName = path.basename(srcPath).slice(0, -3);
-    const root = path.dirname(document.uri.fsPath);
+    const root = workspaceRoot ?? path.dirname(document.uri.fsPath);
 
     return {
       srcRootFolder: root,
+      usesWorkspaceRoot: !!workspaceRoot,
       srcPath: srcPath,
       moduleName: moduleName,
       isUsingConfFile: isUsingCfgFile,

--- a/src/test/fixtures/issues/workspace_root_run/manim.cfg
+++ b/src/test/fixtures/issues/workspace_root_run/manim.cfg
@@ -1,0 +1,3 @@
+[CLI]
+media_dir = out_root
+verbosity = WARNING

--- a/src/test/fixtures/issues/workspace_root_run/src/scene.py
+++ b/src/test/fixtures/issues/workspace_root_run/src/scene.py
@@ -1,0 +1,6 @@
+from manim import *
+
+
+class ImageScene(Scene):
+    def construct(self):
+        self.add(Circle())

--- a/src/test/unit/runRoot.test.ts
+++ b/src/test/unit/runRoot.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import * as assert from "assert";
+import * as path from "path";
+
+import { findManimConfigPath, resolveSceneFileArg } from "../../runRoot";
+
+const ROOT = path.join(path.sep, "project");
+const SRC = path.join(ROOT, "src", "main.py");
+const SRC_DIR_CFG = path.join(ROOT, "src", "manim.cfg");
+const ROOT_CFG = path.join(ROOT, "manim.cfg");
+
+test("explicit config path always wins", () => {
+  const picked = findManimConfigPath("/custom/manim.cfg", SRC, ROOT, () => true);
+  assert.strictEqual(picked, "/custom/manim.cfg");
+});
+
+test("no run root: legacy next-to-file path, even if it does not exist", () => {
+  const picked = findManimConfigPath("", SRC, undefined, () => false);
+  assert.strictEqual(picked, SRC_DIR_CFG);
+});
+
+test("run root with a manim.cfg: root config is preferred", () => {
+  const picked = findManimConfigPath("", SRC, ROOT, (p) => p === ROOT_CFG);
+  assert.strictEqual(picked, ROOT_CFG);
+});
+
+test("run root without a manim.cfg: falls back to next-to-file", () => {
+  const picked = findManimConfigPath("", SRC, ROOT, () => false);
+  assert.strictEqual(picked, SRC_DIR_CFG);
+});
+
+test("scene arg is relative to the run root when the feature is on", () => {
+  const arg = resolveSceneFileArg(SRC, ROOT, true);
+  assert.strictEqual(arg, path.join("src", "main.py"));
+});
+
+test("scene arg stays absolute when the feature is off", () => {
+  assert.strictEqual(resolveSceneFileArg(SRC, ROOT, false), SRC);
+});
+
+test("scene arg stays absolute for a file outside the run root", () => {
+  const outside = path.join(path.sep, "elsewhere", "main.py");
+  assert.strictEqual(resolveSceneFileArg(outside, ROOT, true), outside);
+});


### PR DESCRIPTION
## Problem

The extension always spawns manim with cwd set to the scene file's own directory. Users who keep scenes in subfolders (e.g. `src/main.py`) cannot get the equivalent of running `manim src/main.py` from the project root:

- one root-level `manim.cfg` cannot apply to all scenes, since manim reads `manim.cfg` from the invocation cwd
- a `media/` folder is generated inside every subfolder
- relative asset paths inside scenes resolve against the subfolder instead of the project root

## Design

New boolean setting `manim-sideview.runFromWorkspaceRoot`, default **false** (off means behavior is unchanged from today).

When enabled and the file is inside a workspace folder (`vscode.workspace.getWorkspaceFolder`, so multi-root workspaces resolve correctly):

- the spawn cwd (`srcRootFolder`) becomes that workspace folder
- the scene file is passed to manim as a path relative to that root, matching a manual `manim src/main.py` invocation
- `manim.cfg` discovery prefers the run root (the cwd manim actually reads it from), falling back to next-to-file if none exists at the root
- disk-probe output predictions already join on `srcRootFolder`, so they follow the new root automatically

Fallback rules: a file outside any workspace folder silently keeps the current behavior, and an explicitly set config path always wins for cfg discovery.

## Tests

- Unit (`npm run test:unit`): the cfg-discovery ordering and scene-argument logic are extracted into the vscode-free module `src/runRoot.ts` and tested directly (7 new cases).
- Contract (`npm run test:contract`, CI only since it needs a real manim): new case rendering a subfolder scene from the project root with a root `manim.cfg` (custom `media_dir` + `verbosity WARNING`), asserting the disk probe finds output under the root media dir and nothing leaks into the subfolder. Fixture: `src/test/fixtures/issues/workspace_root_run/`.
- Verified locally: `npm run lint` (only the pre-existing eqeqeq warning), `npm run compile`, `npm run test:unit` all pass. manim is not installed locally, so the contract tests run in CI's manim matrix.

## Manual verification

1. Open `src/test/fixtures/issues/workspace_root_run/` as the workspace folder in the dev host.
2. Enable `manim-sideview.runFromWorkspaceRoot` and render `src/scene.py` scene `ImageScene`.
3. Expect: root `manim.cfg` picked up, image lands in `out_root/` at the workspace root, preview works.
4. Disable the setting and render again: media appears next to the file as before.

Intended for the release after 0.4.0; no version or changelog changes here.

Closes #144 (project files nested inside directories, shared manim.cfg at the root).