### PR TITLE
fix: exclude development files from the vsix, bump 0.4.1

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,7 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+.claude/**
+.github/**
+scripts/**
+TESTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.1
+
+- Repackaged 0.4.0: the published vsix accidentally bundled local development
+  files, inflating its size. No functional changes.
+
 ## 0.4.0
 
 ### Output path resolution

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-sideview",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-sideview",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
         "axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "name": "Ricky",
     "url": "https://github.com/Rickaym"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "Rickaym",
   "engines": {
     "vscode": "^1.68.0"


### PR DESCRIPTION
The published 0.4.0 vsix accidentally bundled a leftover .claude/worktrees directory (5 MB of local development files) plus CI workflow, contract-test script, and TESTING.md. Extends .vscodeignore to exclude them and bumps to 0.4.1 for a clean republish, since the marketplace does not allow replacing an existing version. Verified: repackaged vsix is 127 files / 2.34 MB with none of the stray paths.