### PR TITLE
test: opengl renderer contract case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
             python: "3.11"
           - manim: "manim>=0.19"
             python: "3.12"
-    name: contract (${{ matrix.manim }})
+          # opengl renderer leg (issue #97): needs a GL context via xvfb/mesa
+          - manim: "manim>=0.19"
+            python: "3.12"
+            opengl: true
+    name: contract (${{ matrix.manim }}${{ matrix.opengl && ', opengl' || '' }})
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -64,5 +68,12 @@ jobs:
       # ffmpeg is needed by manim <= 0.18, which shells out to it (0.19+
       # bundles pyav)
       - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config ffmpeg
+      - if: matrix.opengl
+        run: sudo apt-get install -y xvfb libgl1 libegl1 libglu1-mesa
       - run: pip install "${{ matrix.manim }}"
-      - run: npm run test:contract
+      - if: '!matrix.opengl'
+        run: npm run test:contract
+      - if: matrix.opengl
+        run: xvfb-run -a npm run test:contract
+        env:
+          OPENGL_CONTRACT: "1"

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -229,5 +229,49 @@ function check(name, fn) {
   fs.rmSync(cwd, { recursive: true, force: true });
 }
 
+// 6. opengl renderer via commandLineArgs-style flags (issue #97).
+// Needs a GL context, so it only runs when OPENGL_CONTRACT=1 (CI provides
+// xvfb and mesa for this leg).
+if (process.env.OPENGL_CONTRACT === "1") {
+  const cwd = freshDir("opengl");
+  fs.copyFileSync(
+    path.join(FIXTURES, "scenes", "video_scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  const render = run(
+    ["--renderer=opengl", "--write_to_movie", "-ql", "scene.py", "VideoScene"],
+    cwd
+  );
+  const logbook = render.stdout + render.stderr;
+
+  check("opengl: renders and the output path resolves", () => {
+    assert.strictEqual(render.status, 0, `manim exited ${render.status}:\n${logbook}`);
+    const parsed = parseMediaOutputFromLog(logbook);
+    if (parsed) {
+      assert.ok(
+        fs.existsSync(parsed.mediaPath),
+        `parsed path does not exist: ${parsed.mediaPath}`
+      );
+    } else {
+      // opengl may log differently; the disk probe fallback must still work
+      const predictedVideo = path.join(
+        cwd,
+        "media",
+        "videos",
+        "scene",
+        "480p15",
+        "VideoScene.mp4"
+      );
+      assert.ok(
+        fs.existsSync(predictedVideo),
+        `no File ready log and no file at ${predictedVideo}; logs:\n${logbook}`
+      );
+    }
+  });
+  fs.rmSync(cwd, { recursive: true, force: true });
+} else {
+  console.log("[SKIP] opengl renderer (set OPENGL_CONTRACT=1 to enable)");
+}
+
 console.log(failures === 0 ? "\nCONTRACT TESTS PASSED" : `\n${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Verifies issue #97: renders the video fixture with --renderer=opengl --write_to_movie through the real manim and asserts the extension's output resolution finds the result, via the File ready log line or the disk-probe fallback. The case is gated behind OPENGL_CONTRACT=1 and runs in a dedicated CI leg with xvfb and mesa, so local runs and the existing legs are unaffected. If the leg passes, #97 can be closed by documenting the commandLineArgs incantation; if it fails, the log output will show the remaining gap.