### PR TITLE
fix: register commands even when the Python extension is unavailable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,9 +12,24 @@ import { PythonExtension } from "@vscode/python-extension";
 
 export async function activate(context: vscode.ExtensionContext) {
   Log.info("Activating extension.");
-  await loadGlobals(context);
 
-  const pythonApi: PythonExtension = await PythonExtension.api();
+  try {
+    await loadGlobals(context);
+  } catch (e) {
+    vscode.window.showErrorMessage(
+      `Manim Sideview: Failed to load extension globals. ${e}`
+    );
+  }
+
+  let pythonApi: PythonExtension | undefined;
+  try {
+    pythonApi = await PythonExtension.api();
+  } catch (e) {
+    Log.warn(
+      "Python extension unavailable; interpreter-based manim resolution disabled" +
+        ` - set an absolute defaultManimPath or put manim on PATH. (${e})`
+    );
+  }
   const sideview = new ManimSideview(context, pythonApi);
 
   context.subscriptions.push(

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -103,7 +103,7 @@ function getActivationEnvironment(
 export class ManimSideview {
   constructor(
     public readonly ctx: vscode.ExtensionContext,
-    public readonly pythonApi: PythonExtension
+    public readonly pythonApi: PythonExtension | undefined
   ) {
     this.ctx = ctx;
     this.pythonApi = pythonApi;
@@ -487,7 +487,7 @@ export class ManimSideview {
   }
 
   private async getPythonEnvironment() {
-    if (!this.pythonApi.environments) {
+    if (!this.pythonApi?.environments) {
       return;
     }
     const environmentPath =


### PR DESCRIPTION
## Symptom

Every UI entry point fails with `command 'manim-sideview.run' not found` for some users.

## Root cause

`activate()` awaited `PythonExtension.api()` before registering any commands. If the ms-python extension is disabled, missing, or fails its own activation (plausible for users with no local Python, e.g. Docker-only setups), that promise rejects, activation dies, and none of the eleven commands are ever registered. The `extensionDependencies` entry on `ms-python.python` does not cover the disabled/failed cases.

The Python API is only genuinely needed lazily, in `getPythonEnvironment()`, and only when `defaultManimPath` is not absolute.

## Fix

- Wrap the `PythonExtension.api()` acquisition in try/catch; on failure log a warning (interpreter-based manim resolution disabled, set an absolute `defaultManimPath` or put manim on PATH) and continue with `undefined`.
- `ManimSideview` now accepts `PythonExtension | undefined` and `getPythonEnvironment()` is null-safe.
- `loadGlobals()` failures surface via `vscode.window.showErrorMessage` instead of silently aborting activation.

Command registration can no longer be stripped by a failing Python extension.

Addresses the activation failure reported in #129. Docker/customCommand execution support remains a separate future feature and is not part of this change.