### PR TITLE
fix: enable audio in the video preview

### DIFF
--- a/webview/player/player.html
+++ b/webview/player/player.html
@@ -70,7 +70,7 @@
                 />
               </svg>
             </button>
-            <div class="volume-container" style="display: none">
+            <div class="volume-container">
               <button
                 class="control-button"
                 id="volume-button"

--- a/webview/player/player.js
+++ b/webview/player/player.js
@@ -43,6 +43,8 @@ const sourceFileDisplay = document.getElementById("source-file");
 let isVideoMode = !videoPlayer.hidden;
 let controlsTimeout;
 let wasPausedBeforeSeek = false;
+// Tracks whether the user has explicitly set mute or volume themselves.
+let userTouchedVolume = false;
 
 // --- Helper Functions ---
 
@@ -111,10 +113,21 @@ function showControls() {
   controlsContainer.classList.add("visible");
 }
 
+// The video starts "autoplay muted" to satisfy the autoplay policy.
+// Unmute on the first real user interaction unless the user muted it.
+function unmuteOnFirstInteraction() {
+  if (!isVideoMode || userTouchedVolume) return;
+  if (video.muted) {
+    video.muted = false;
+    updateVolumeIcon();
+  }
+}
+
 // --- Core Functionality ---
 
 function togglePlayPause() {
   if (!isVideoMode) return;
+  unmuteOnFirstInteraction();
   if (video.paused) {
     video.play();
   } else {
@@ -135,6 +148,7 @@ function skip(duration) {
 
 function toggleMute() {
   if (!isVideoMode) return;
+  userTouchedVolume = true;
   video.muted = !video.muted;
   if (!video.muted && video.volume === 0) {
     // Unmuting but volume was 0
@@ -286,6 +300,7 @@ playPauseButton.addEventListener("click", togglePlayPause);
 volumeButton.addEventListener("click", toggleMute);
 volumeSlider.addEventListener("input", (e) => {
   if (!isVideoMode) return;
+  userTouchedVolume = true;
   video.volume = e.target.value;
   video.muted = video.volume === 0; // Mute if slider dragged to 0
   updateVolumeIcon(); // Update icon immediately


### PR DESCRIPTION
## Problem

Videos rendered with audio tracks (e.g. manim-voiceover output) play permanently silent in the sideview player (#107). Codecs are not the issue; the same webview plays H.264 fine.

## Root cause

Two things combined:

- When `previewAutoPlay` is on (the default), the video tag is injected with `autoplay muted` (`src/player.ts`). The `muted` attribute is required by Chromium's autoplay policy, but nothing ever unmuted the video afterwards.
- The volume controls (mute button and volume slider) exist and are fully wired up in `webview/player/player.js`, but the `.volume-container` in `webview/player/player.html` was hidden with `style="display: none"`, so users had no way to unmute.

## Fix

- Show the existing volume controls (removed the inline `display: none`; the CSS already lays the container out correctly next to the play button).
- Keep `autoplay muted` for the autoplay policy, but unmute on the first real user interaction with the player (play/pause via button, video click, or space bar). If the user explicitly muted via the button or dragged the volume slider, the player respects that and never force-unmutes (`userTouchedVolume` flag).
- The reload path leaves mute state untouched and re-syncs the volume icon, so state stays consistent across re-renders.

## Verification

`npm run lint`, `npm run compile`, and `npm run test:unit` pass (one pre-existing eqeqeq warning in `sideview.ts` remains, unrelated). There are no automated tests for the webview JS, and headless manual playback verification is not possible here. To verify manually in the Extension Development Host:

1. Render a scene with an audio track (e.g. a manim-voiceover scene).
2. The video autoplays muted; click play/pause (or the video, or space) and confirm audio is audible.
3. Confirm the volume button and slider are visible next to the play button, that muting via the button sticks (no forced unmute afterwards), and that re-rendering keeps the chosen mute state.

Closes #107