### PR TITLE
fix: probe the Scripts folder for manim in conda-style Windows environments

### DIFF
--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -30,7 +30,11 @@ import {
   probeMediaOnDisk,
   baseName,
 } from "./mediaResolution";
-import { buildSpawnEnv } from "./spawnEnv";
+import {
+  buildSpawnEnv,
+  PYTHON_ENV_SCRIPTS_FOLDER,
+  resolveManimNextToInterpreter,
+} from "./spawnEnv";
 
 const CONFIG_SECTION = "CLI";
 const RELEVANT_CONFIG_OPTIONS = [
@@ -45,12 +49,6 @@ const RELEVANT_CONFIG_OPTIONS = [
 
 const RE_SCENE_CLASS = /class\s+(?<name>\w+)\([\w,\s.]*Scene\b[\w,\s]*\):/g;
 const RE_CFG_OPTIONS = /(\w+)\s?:\s?([^ ]*)/g;
-
-const PYTHON_ENV_SCRIPTS_FOLDER = {
-  win32: "Scripts",
-  darwin: "bin",
-  linux: "bin",
-};
 
 type MediaInfo = {
   fileType: number;
@@ -406,7 +404,14 @@ export class ManimSideview {
         }
 
         if (pythonBinDir) {
-          manimPath = path.join(pythonBinDir, manimPath);
+          // Conda-style envs on Windows keep python.exe at the prefix root
+          // but manim.exe under Scripts; probe both (#127, #133).
+          const resolved = resolveManimNextToInterpreter(
+            pythonBinDir,
+            manimPath
+          );
+          manimPath = resolved.manim;
+          pythonBinDir = resolved.binDir;
           Log.info(`Resolved manim path: ${manimPath}`);
         }
       }

--- a/src/spawnEnv.ts
+++ b/src/spawnEnv.ts
@@ -20,6 +20,57 @@ import * as path from "path";
  * venv environments) are found (#98).
  */
 
+export const PYTHON_ENV_SCRIPTS_FOLDER = {
+  win32: "Scripts",
+  darwin: "bin",
+  linux: "bin",
+};
+
+const executableFileExists = (p: string): boolean => {
+  try {
+    return fs.existsSync(p) && fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Locate manim relative to the python interpreter's directory. On Windows,
+ * conda-style environments (conda, mamba, pixi) place python.exe at the env
+ * prefix root while entry-point executables like manim.exe live under
+ * `<prefix>\Scripts`, so the interpreter's directory alone is not enough.
+ * Probes the interpreter directory first, then its scripts subfolder.
+ * Returns the resolved path and the directory it lives in; when neither
+ * candidate exists, returns the root candidate unchanged so callers keep
+ * their existing not-found handling.
+ */
+export function resolveManimNextToInterpreter(
+  interpreterDir: string,
+  manimName: string,
+  platform: NodeJS.Platform = process.platform,
+  exists: (p: string) => boolean = executableFileExists
+): { manim: string; binDir: string } {
+  // Mirror checkExecutableExists, which probes both the bare name and .exe.
+  const executableExists = (p: string) => exists(p) || exists(p + ".exe");
+
+  const rootCandidate = path.join(interpreterDir, manimName);
+  if (executableExists(rootCandidate)) {
+    return { manim: rootCandidate, binDir: interpreterDir };
+  }
+
+  const scriptsFolder =
+    PYTHON_ENV_SCRIPTS_FOLDER[
+      platform as keyof typeof PYTHON_ENV_SCRIPTS_FOLDER
+    ] || PYTHON_ENV_SCRIPTS_FOLDER["linux"];
+  const scriptsDir = path.join(interpreterDir, scriptsFolder);
+  const scriptsCandidate = path.join(scriptsDir, manimName);
+  if (executableExists(scriptsCandidate)) {
+    return { manim: scriptsCandidate, binDir: scriptsDir };
+  }
+
+  return { manim: rootCandidate, binDir: interpreterDir };
+}
+
 export type SpawnEnvDeps = {
   platform: NodeJS.Platform;
   baseEnv: NodeJS.ProcessEnv;

--- a/src/test/unit/manimResolution.test.ts
+++ b/src/test/unit/manimResolution.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import * as assert from "assert";
+import * as path from "path";
+
+import { resolveManimNextToInterpreter } from "../../spawnEnv";
+
+const existsIn = (files: string[]) => (p: string) => files.includes(p);
+
+test("unix env resolves manim next to the interpreter in bin", () => {
+  const bin = "/envs/anim/bin";
+  const result = resolveManimNextToInterpreter(
+    bin,
+    "manim",
+    "linux",
+    existsIn([path.join(bin, "manim")])
+  );
+  assert.strictEqual(result.manim, path.join(bin, "manim"));
+  assert.strictEqual(result.binDir, bin);
+});
+
+test("windows venv with manim beside python in Scripts does not double-append", () => {
+  const scripts = path.join(path.sep, "proj", ".venv", "Scripts");
+  const result = resolveManimNextToInterpreter(
+    scripts,
+    "manim",
+    "win32",
+    existsIn([path.join(scripts, "manim") + ".exe"])
+  );
+  assert.strictEqual(result.manim, path.join(scripts, "manim"));
+  assert.strictEqual(result.binDir, scripts);
+});
+
+test("windows conda-style env falls back to the Scripts subfolder", () => {
+  const prefix = path.join(path.sep, "u", ".pixi", "envs", "default");
+  const scripts = path.join(prefix, "Scripts");
+  const result = resolveManimNextToInterpreter(
+    prefix,
+    "manim",
+    "win32",
+    existsIn([path.join(scripts, "manim") + ".exe"])
+  );
+  assert.strictEqual(result.manim, path.join(scripts, "manim"));
+  assert.strictEqual(result.binDir, scripts);
+});
+
+test("not found anywhere returns the root candidate unchanged", () => {
+  const prefix = path.join(path.sep, "envs", "anim");
+  const result = resolveManimNextToInterpreter(
+    prefix,
+    "manim",
+    "win32",
+    () => false
+  );
+  assert.strictEqual(result.manim, path.join(prefix, "manim"));
+  assert.strictEqual(result.binDir, prefix);
+});
+
+test("unknown platform assumes the unix bin layout", () => {
+  const prefix = "/envs/anim";
+  const result = resolveManimNextToInterpreter(
+    prefix,
+    "manim",
+    "sunos" as NodeJS.Platform,
+    existsIn([path.join(prefix, "bin", "manim")])
+  );
+  assert.strictEqual(result.manim, path.join(prefix, "bin", "manim"));
+  assert.strictEqual(result.binDir, path.join(prefix, "bin"));
+});


### PR DESCRIPTION
## User report

A Windows 11 user with a pixi environment got this on first activation:

> Manim is not found in PATH or at the specified location "c:\Users\jake\...\.pixi\envs\default\Manim"

The real executable was at `c:\Users\jake\...\.pixi\envs\default\Scripts\manim.exe`. The only workaround was to manually paste the Scripts path into `defaultManimPath`.

## Root cause

When `defaultManimPath` is relative, `getManimPath()` asks the Python extension for the active environment and takes `path.dirname(env.executable.uri)` as the directory to find manim in. Conda-style environments (conda, mamba, pixi) on Windows put `python.exe` at the env prefix root, not in `Scripts`, so that dirname is the prefix itself and the probed path becomes `<prefix>\manim`, which does not exist. Entry-point executables live in `<prefix>\Scripts\`. The existing `PYTHON_ENV_SCRIPTS_FOLDER` fallback only fires when the API reports no executable at all, so it never helped here. Unix layouts are unaffected since python and manim share `<prefix>/bin`.

## Fix

New pure helper `resolveManimNextToInterpreter` in `src/spawnEnv.ts` (vscode-free, injectable exists/platform): probe the interpreter directory first, then the platform scripts subfolder (`Scripts` on win32, `bin` elsewhere), matching `checkExecutableExists` by also probing the `.exe` suffix. `getManimPath()` uses it and keeps `binDir` consistent with wherever manim actually resolved, so spawn PATH injection via `buildSpawnEnv` still points at the right directory. All other cases behave exactly as before, including the not-found path.

## Tests

New `src/test/unit/manimResolution.test.ts` (node:test) covering: unix bin layout, Windows venv where python and manim share Scripts (no double-append), Windows conda-style layout with manim under Scripts, not-found returning the root candidate unchanged, and unknown platforms defaulting to the unix layout. `npm run lint`, `npm run compile`, and `npm run test:unit` all pass.

Related: #127, #133