### PR TITLE
test: add extension-host integration tests that render real scenes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,27 @@ jobs:
         run: xvfb-run -a npm run test:contract
         env:
           OPENGL_CONTRACT: "1"
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: npm ci
+      - run: sudo apt-get update && sudo apt-get install -y libpango1.0-dev pkg-config ffmpeg
+      - run: pip install "manim>=0.19"
+      # the downloaded VSCode build; keyed loosely on the engines range
+      - uses: actions/cache@v4
+        with:
+          path: .vscode-test
+          key: vscode-test-${{ runner.os }}-stable
+      # ms-python.python is intentionally NOT installed: this exercises the
+      # activation path that tolerates a missing python extension. The manim
+      # path is absolute, so interpreter resolution is never needed.
+      - run: MANIM_BIN=$(which manim) xvfb-run -a npm run test:integration

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,22 @@
 import { defineConfig } from "@vscode/test-cli";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+
+// Integration tests copy fixtures into this throwaway workspace so the
+// repository tree stays clean during renders.
+const workspace = path.join(tmpdir(), "manim-sideview-it-workspace");
+mkdirSync(workspace, { recursive: true });
 
 export default defineConfig({
   files: "out/test/suite/**/*.test.js",
+  workspaceFolder: workspace,
+  mocha: {
+    ui: "tdd",
+    // real manim renders; each scene can take a while on cold CI runners
+    timeout: 120000,
+  },
+  env: {
+    MANIM_SIDEVIEW_TEST_WORKSPACE: workspace,
+  },
 });

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Three tiers, from fastest to most end-to-end. Fixtures for all tiers live
+Four tiers, from fastest to most end-to-end. Fixtures for all tiers live
 in `src/test/fixtures/`.
 
 ## 1. Unit tests (no manim, no VSCode)
@@ -28,7 +28,34 @@ on. Cases: video render with `-ql`, image render, silent logs under
 `verbosity = WARNING` (disk probe), and a `manim.cfg` with trailing
 whitespace in the quality value.
 
-## 3. Manual checks (Extension Development Host)
+## 3. Integration tests (real manim, real VSCode)
+
+```
+npm run test:integration
+```
+
+Downloads a real VSCode build via `@vscode/test-cli`, activates the
+extension inside it, and drives renders end to end through
+`vscode.commands.executeCommand("manim-sideview.run", uri, false, sceneName)`.
+The third argument is a scene-name hook: when given, `cmdRun` uses it
+directly instead of showing the quick pick, so headless runs never block
+on UI. This is the tier that catches activation bugs and command wiring
+that the lower tiers cannot see.
+
+The suite (`src/test/suite/`, mocha tdd) copies fixtures into a temp
+workspace (`.vscode-test.mjs` opens it as the workspace folder), asserts
+on the `RenderResult` returned by the run command, and covers: activation
+plus command registration with ms-python.python absent, a `-ql` video
+render via `commandLineArgs`, an image render, the silent-log disk probe
+(#139), and a custom `media_dir`.
+
+Requirements: a display or `xvfb-run -a npm run test:integration`, and a
+manim executable, taken from `MANIM_BIN` (absolute path) or the PATH. If
+no manim is found, the render tests skip with a message and only the
+activation test runs. The suite syncs `manim-sideview.manimExecutableVersion`
+to the detected manim version automatically.
+
+## 4. Manual checks (Extension Development Host)
 
 Press F5 in this repo, then in the dev host window open the fixture folder
 listed per row. All fixtures render in under a minute at low quality.
@@ -45,5 +72,8 @@ listed per row. All fixtures render in under a minute at low quality.
 ## CI
 
 `.github/workflows/ci.yml` runs lint, both compile targets, and the unit
-tests on every push and pull request, and the contract tests against a real
-pip-installed manim on ubuntu.
+tests on every push and pull request, the contract tests against a real
+pip-installed manim on ubuntu, and the integration tests in a downloaded
+VSCode under xvfb (`integration` job). The integration job intentionally
+does not install ms-python.python, which exercises the activation path
+that tolerates a missing python extension.

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "onCommand:manim-sideview.showExtensionManimConfig",
     "onCommand:manim-sideview.showManimExecTerminal"
   ],
-  "extensionDependencies": [
-    "ms-python.python"
-  ],
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {
@@ -197,6 +194,8 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "vscode-test",
+    "pretest:integration": "npm run compile-tests && npm run compile",
+    "test:integration": "vscode-test",
     "test:unit": "npm run compile-tests && node --test out/test/unit/",
     "test:contract": "npm run compile-tests && node scripts/contract-test.js"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,4 +108,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   Log.info("Activated extension.");
+
+  // Exposed for integration tests; not part of the public extension API.
+  return { sideview };
 }

--- a/src/sideview.ts
+++ b/src/sideview.ts
@@ -60,6 +60,13 @@ type MediaInfo = {
   mediaPath?: string;
 };
 
+// Returned by cmdRun so callers (tests, automation) can observe the render
+// outcome without going through the UI.
+export type RenderResult = {
+  mediaType: number;
+  outputPath: string;
+};
+
 // a process will be killed if this message is seen
 const KILL_MSG =
   "Choose number corresponding to desired scene/arguments.\r\n(Use comma separated list for multiple entries)\r\nChoice(s):  ";
@@ -134,8 +141,14 @@ export class ManimSideview {
    * @param srcPath path to the src file, if undefined, the active text document is used
    * @param autoRun denotes whether if this call is from
    * an automated runner like RunOnSave
+   * @param sceneName when given, used directly instead of prompting the
+   * user with a quick pick; lets tests and automation drive a render
    */
-  async cmdRun(srcPath?: vscode.Uri | string, autoRun?: boolean) {
+  async cmdRun(
+    srcPath?: vscode.Uri | string,
+    autoRun?: boolean,
+    sceneName?: string
+  ): Promise<RenderResult | undefined> {
     let activeJob = srcPath
       ? this.jobManager.getActiveJob(
         typeof srcPath === "string" ? srcPath : srcPath.fsPath
@@ -195,9 +208,13 @@ export class ManimSideview {
       // if there is an active job simply resume
       activeJob.config.manimConfig = manimConfig;
       activeJob.config.isUsingConfFile = isConfFile;
+      if (sceneName) {
+        activeJob.config.sceneName = sceneName;
+      }
       currentRunningConfig = activeJob.config;
     } else {
-      const newSceneName = await this.getRenderSceneName(document.uri);
+      const newSceneName =
+        sceneName ?? (await this.getRenderSceneName(document.uri));
       if (!newSceneName) {
         return;
       }
@@ -213,7 +230,7 @@ export class ManimSideview {
       );
     }
 
-    this.render(currentRunningConfig);
+    return this.render(currentRunningConfig);
   }
 
   async cmdStop() {
@@ -563,7 +580,9 @@ export class ManimSideview {
    *
    * @param config the running configuration
    */
-  private async render(config: RunningConfig) {
+  private async render(
+    config: RunningConfig
+  ): Promise<RenderResult | undefined> {
     Log.info(
       "Attempting to render via the running configuration " +
       JSON.stringify(config, null, 4) +
@@ -595,83 +614,87 @@ export class ManimSideview {
       config.sceneName.trim(),
     ];
 
-    this.spawnManimProcess(
+    const mediaInfo = await this.spawnManimProcess(
       manim.manim,
       args,
       cwd,
       manim.binDir,
       config.srcPath,
-      config.sceneName,
-      (mediaInfo) => {
-        Log.info(`Running process for "${config.sceneName}" has finished.`);
-        // Trust manim's actual output path (from its log or a filesystem probe)
-        // over the static recompute, which doesn't account for CLI flags like
-        // -ql / -qm that change the quality directory.
-        const resolvedPath =
-          mediaInfo.mediaPath ??
-          (mediaInfo.fileType === PlayableMediaType.Video
-            ? getVideoOutputPath(config)
-            : getImageOutputPath(config, mediaInfo.imageName));
-
-        const filePath = vscode.Uri.file(
-          path.isAbsolute(resolvedPath)
-            ? resolvedPath
-            : path.join(config.srcRootFolder, resolvedPath)
-        );
-        Log.info(
-          `Predicted output file path is "${filePath.fsPath}" for "${config.sceneName}".`
-        );
-
-        if (!fs.existsSync(filePath.fsPath)) {
-          vscode.window
-            .showErrorMessage(
-              Log.error(
-                `Manim Sideview: Predicted output file does not exist at "${filePath.fsPath}"` +
-                " Make sure that the designated video directories are reflected" +
-                " in the extension log."
-              ),
-              "Show Log"
-            )
-            .then((value?: String) =>
-              value === "Show Log"
-                ? vscode.commands.executeCommand(
-                  "manim-sideview.showOutputChannel"
-                )
-                : null
-            );
-          throw new Error(
-            "Manim Sideview: Predicted output file does not exist."
-          );
-        }
-
-        if (getUserConfiguration("preview")) {
-          // we'll open a side view
-          this.mediaPlayer.playMedia(filePath, config, mediaInfo.fileType);
-        }
-
-        // we'll execute the post render terminal command if it exists
-        this.executeTerminalCommand(
-          filePath.fsPath,
-          config.srcPath,
-          config.sceneName,
-          cwd
-        );
-
-        const job = this.jobManager.getActiveJob(config.srcPath);
-        if (job) {
-          this.jobManager.setActive(job);
-        } else {
-          Log.info(
-            `New job added for "${config.srcPath}" as ${JSON.stringify(
-              config,
-              null,
-              4
-            )}`
-          );
-          this.jobManager.addJob(config, mediaInfo.fileType);
-        }
-      }
+      config.sceneName
     );
+    if (!mediaInfo) {
+      return;
+    }
+
+    Log.info(`Running process for "${config.sceneName}" has finished.`);
+    // Trust manim's actual output path (from its log or a filesystem probe)
+    // over the static recompute, which doesn't account for CLI flags like
+    // -ql / -qm that change the quality directory.
+    const resolvedPath =
+      mediaInfo.mediaPath ??
+      (mediaInfo.fileType === PlayableMediaType.Video
+        ? getVideoOutputPath(config)
+        : getImageOutputPath(config, mediaInfo.imageName));
+
+    const filePath = vscode.Uri.file(
+      path.isAbsolute(resolvedPath)
+        ? resolvedPath
+        : path.join(config.srcRootFolder, resolvedPath)
+    );
+    Log.info(
+      `Predicted output file path is "${filePath.fsPath}" for "${config.sceneName}".`
+    );
+
+    if (!fs.existsSync(filePath.fsPath)) {
+      vscode.window
+        .showErrorMessage(
+          Log.error(
+            `Manim Sideview: Predicted output file does not exist at "${filePath.fsPath}"` +
+            " Make sure that the designated video directories are reflected" +
+            " in the extension log."
+          ),
+          "Show Log"
+        )
+        .then((value?: String) =>
+          value === "Show Log"
+            ? vscode.commands.executeCommand(
+              "manim-sideview.showOutputChannel"
+            )
+            : null
+        );
+      throw new Error(
+        "Manim Sideview: Predicted output file does not exist."
+      );
+    }
+
+    if (getUserConfiguration("preview")) {
+      // we'll open a side view
+      this.mediaPlayer.playMedia(filePath, config, mediaInfo.fileType);
+    }
+
+    // we'll execute the post render terminal command if it exists
+    this.executeTerminalCommand(
+      filePath.fsPath,
+      config.srcPath,
+      config.sceneName,
+      cwd
+    );
+
+    const job = this.jobManager.getActiveJob(config.srcPath);
+    if (job) {
+      this.jobManager.setActive(job);
+    } else {
+      Log.info(
+        `New job added for "${config.srcPath}" as ${JSON.stringify(
+          config,
+          null,
+          4
+        )}`
+      );
+      this.jobManager.addJob(config, mediaInfo.fileType);
+    }
+
+    return { mediaType: mediaInfo.fileType, outputPath: filePath.fsPath };
   }
 
   /**
@@ -682,16 +705,29 @@ export class ManimSideview {
    * @param args arguments for the command
    * @param cwd the current working directory
    * @param config the running configuration
-   * @returns
+   * @returns the media info on success, undefined on failure or termination
    */
-  private async spawnManimProcess(
+  private spawnManimProcess(
+    command: string,
+    args: string[],
+    cwd: string,
+    binDir: string | undefined,
+    srcPath: string,
+    sceneName: string
+  ): Promise<MediaInfo | undefined> {
+    return new Promise((resolve) => {
+      this.doSpawnManimProcess(command, args, cwd, binDir, srcPath, sceneName, resolve);
+    });
+  }
+
+  private doSpawnManimProcess(
     command: string,
     args: string[],
     cwd: string,
     binDir: string | undefined,
     srcPath: string,
     sceneName: string,
-    onProcessClose: (m: MediaInfo) => void
+    onProcessClose: (m: MediaInfo | undefined) => void
   ) {
     const startTime = new Date();
     const process = spawn(command, args, {
@@ -811,16 +847,21 @@ export class ManimSideview {
         if (isMainProcess) {
           this.jobManager.setError(job);
         }
+        onProcessClose(undefined);
         return;
       }
 
-      const mediaInfo = await this.getMediaFileInfo(
-        stdoutLogbook,
-        srcPath,
-        sceneName
-      );
-
-      onProcessClose(mediaInfo);
+      try {
+        const mediaInfo = await this.getMediaFileInfo(
+          stdoutLogbook,
+          srcPath,
+          sceneName
+        );
+        onProcessClose(mediaInfo);
+      } catch (e) {
+        Log.error(`Failed to determine media output: ${e}`);
+        onProcessClose(undefined);
+      }
     });
 
     Log.info(

--- a/src/test/suite/integration.test.ts
+++ b/src/test/suite/integration.test.ts
@@ -1,0 +1,181 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+import * as vscode from "vscode";
+import { PlayableMediaType } from "../../player";
+import type { RenderResult } from "../../sideview";
+
+const EXTENSION_ID = "Rickaym.manim-sideview";
+
+// out/test/suite -> repository root
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const fixturesRoot = path.join(repoRoot, "src", "test", "fixtures");
+const workspaceRoot = process.env.MANIM_SIDEVIEW_TEST_WORKSPACE!;
+
+// MANIM_BIN wins so CI can pass an absolute path; otherwise probe the PATH.
+// Returns undefined when no manim exists, in which case render tests skip.
+function resolveManimBin(): string | undefined {
+  const fromEnv = process.env.MANIM_BIN;
+  if (fromEnv && fs.existsSync(fromEnv)) {
+    return fromEnv;
+  }
+  try {
+    const cmd = process.platform === "win32" ? "where manim" : "which manim";
+    const found = execSync(cmd).toString().split(/\r?\n/)[0].trim();
+    return found || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const manimBin = resolveManimBin();
+
+function requireManim(ctx: Mocha.Context) {
+  if (!manimBin) {
+    console.log(
+      "No manim executable found (MANIM_BIN unset and not on PATH); skipping render test."
+    );
+    ctx.skip();
+  }
+}
+
+// Copies a fixture directory into a fresh folder inside the temp workspace,
+// opens the scene file, and drives a render through the scene-name hook.
+async function renderFixture(
+  fixtureDir: string,
+  fileName: string,
+  sceneName: string,
+  commandLineArgs: string = ""
+): Promise<RenderResult | undefined> {
+  const dest = fs.mkdtempSync(path.join(workspaceRoot, "case-"));
+  fs.cpSync(path.join(fixturesRoot, fixtureDir), dest, { recursive: true });
+  const file = path.join(dest, fileName);
+
+  const config = vscode.workspace.getConfiguration("manim-sideview");
+  await config.update(
+    "commandLineArgs",
+    commandLineArgs,
+    vscode.ConfigurationTarget.Workspace
+  );
+
+  const document = await vscode.workspace.openTextDocument(file);
+  await vscode.window.showTextDocument(document);
+
+  return vscode.commands.executeCommand<RenderResult | undefined>(
+    "manim-sideview.run",
+    vscode.Uri.file(file),
+    false,
+    sceneName
+  );
+}
+
+suite("manim-sideview integration", () => {
+  suiteSetup(async () => {
+    const extension = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(extension, "extension not found in the test VSCode");
+    await extension.activate();
+
+    const config = vscode.workspace.getConfiguration("manim-sideview");
+    if (manimBin) {
+      await config.update(
+        "defaultManimPath",
+        manimBin,
+        vscode.ConfigurationTarget.Workspace
+      );
+      // The disk probe predicts image names from this setting; it must
+      // match the real manim version (see the #139 row in TESTING.md).
+      const versionOutput = execSync(`"${manimBin}" --version`).toString();
+      const version = versionOutput.match(/v\d+\.\d+\.\d+/)?.[0];
+      if (version) {
+        await config.update(
+          "manimExecutableVersion",
+          version,
+          vscode.ConfigurationTarget.Workspace
+        );
+      }
+    }
+    // keep renders quiet and predictable in the host window
+    await config.update(
+      "focusOutputOnRun",
+      false,
+      vscode.ConfigurationTarget.Workspace
+    );
+  });
+
+  test("activates and registers all commands without ms-python", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    for (const name of [
+      "manim-sideview.run",
+      "manim-sideview.stop",
+      "manim-sideview.removeAllJobs",
+      "manim-sideview.removeCurrentJob",
+      "manim-sideview.renderNewScene",
+      "manim-sideview.showMobjectGallery",
+      "manim-sideview.syncMobjectGallery",
+      "manim-sideview.updateDefaultManimConfig",
+      "manim-sideview.showOutputChannel",
+      "manim-sideview.showExtensionManimConfig",
+      "manim-sideview.showManimExecTerminal",
+    ]) {
+      assert.ok(commands.includes(name), `command ${name} not registered`);
+    }
+  });
+
+  test("renders a video scene with -ql from settings", async function () {
+    requireManim(this);
+    const result = await renderFixture(
+      "scenes",
+      "video_scene.py",
+      "VideoScene",
+      "-ql"
+    );
+    assert.ok(result, "run command returned no result");
+    assert.strictEqual(result.mediaType, PlayableMediaType.Video);
+    assert.ok(fs.existsSync(result.outputPath), result.outputPath);
+    assert.match(result.outputPath, /\.mp4$/);
+    // -ql renders into the 480p15 quality directory
+    assert.ok(result.outputPath.includes("480p15"), result.outputPath);
+  });
+
+  test("renders an image scene", async function () {
+    requireManim(this);
+    const result = await renderFixture(
+      "scenes",
+      "image_scene.py",
+      "ImageScene",
+      "-ql"
+    );
+    assert.ok(result, "run command returned no result");
+    assert.strictEqual(result.mediaType, PlayableMediaType.Image);
+    assert.ok(fs.existsSync(result.outputPath), result.outputPath);
+    assert.match(result.outputPath, /\.png$/);
+  });
+
+  test("resolves output via disk probe when logs are silent (#139)", async function () {
+    requireManim(this);
+    const result = await renderFixture(
+      path.join("issues", "139_low_verbosity"),
+      "scene.py",
+      "ImageScene"
+    );
+    assert.ok(result, "run command returned no result");
+    assert.strictEqual(result.mediaType, PlayableMediaType.Image);
+    assert.ok(fs.existsSync(result.outputPath), result.outputPath);
+  });
+
+  test("honors a custom media_dir from manim.cfg", async function () {
+    requireManim(this);
+    const result = await renderFixture(
+      path.join("issues", "custom_media_dir"),
+      "scene.py",
+      "ImageScene"
+    );
+    assert.ok(result, "run command returned no result");
+    assert.ok(fs.existsSync(result.outputPath), result.outputPath);
+    assert.ok(
+      result.outputPath.includes("out_custom"),
+      `expected output under out_custom, got ${result.outputPath}`
+    );
+  });
+});


### PR DESCRIPTION
## What this tier covers

Unit tests exercise pure logic and contract tests exercise real manim output parsing, but neither can catch a broken activate(), a miswired command registration, or a regression in the editor-to-render flow. This PR adds tier 3: @vscode/test-cli downloads a real VSCode, loads the extension in an extension host under xvfb, and drives fixture renders end to end, asserting on the resolved output file rather than pixels.

## Scene-name hook

`cmdRun` gains an optional third parameter, so `vscode.commands.executeCommand("manim-sideview.run", uri, false, "SceneName")` bypasses the scene quick pick that would otherwise block a headless run. When omitted, the interactive quick pick behaves exactly as before. `cmdRun` now also resolves with a `RenderResult` (`{ mediaType, outputPath }`) once the render pipeline finishes; internally `spawnManimProcess` returns a promise instead of taking a completion callback, with no behavior change on the interactive path. `activate()` returns `{ sideview }` as a test API.

## ms-python.python dependency change (please review)

VSCode refuses to activate an extension whose `extensionDependencies` entry is not installed ("depends on unknown extension 'ms-python.python'"), verified in the test host. That means the recently hardened `PythonExtension.api()` catch in activate() was unreachable. This PR removes the hard dependency: the extension now activates without ms-python installed, falling back to `defaultManimPath` / PATH for manim resolution. The trade-off is that installing Manim Sideview no longer auto-installs the Python extension.

## The suite

`src/test/suite/integration.test.ts` (mocha tdd, the vscode-test default). Fixtures are copied per test into a temp workspace which `.vscode-test.mjs` opens as the workspace folder, so the repo tree stays clean. Scenarios:

- activation sanity: all 11 commands registered with ms-python absent
- video render of `video_scene.py` with `-ql` via `commandLineArgs` (asserts mp4 in the 480p15 directory)
- image render of `image_scene.py`
- silent logs / disk probe (`139_low_verbosity` fixture with `verbosity = WARNING`)
- custom `media_dir` fixture (asserts output lands under `out_custom`)

## Skip semantics

The manim binary comes from `MANIM_BIN` (absolute path) or a PATH probe. When neither yields an executable, each render test calls `this.skip()` after logging a clear message, and only the activation test runs. The suite also syncs `manim-sideview.manimExecutableVersion` to the detected manim version, since the disk-probe path predicts image names from it (same caveat as the existing #139 manual check).

## CI

New `integration` job modeled on the contract job: node 20, python 3.12, pango headers + ffmpeg, `pip install manim>=0.19`, then `MANIM_BIN=$(which manim) xvfb-run -a npm run test:integration`. The downloaded VSCode in `.vscode-test` is cached. ms-python.python is intentionally not installed.

## Verified where

Locally (linux, xvfb, manim 0.21.0 in a venv passed via MANIM_BIN): all 5 integration tests pass in about 5s after the VSCode download; also verified the no-manim path (1 passing, 4 pending with the skip message). `npm run lint` (one preexisting eqeqeq warning), `npm run compile`, `npm run compile-tests`, and `npm run test:unit` (27 passing) all pass. CI will additionally prove the pip-installed manim on a clean runner.