### PR TITLE
fix: preserve spaces in output paths, 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+- Fixed output paths containing spaces failing to resolve (#136)
+
 ## 0.4.1
 
 - Repackaged 0.4.0: the published vsix accidentally bundled local development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manim-sideview",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manim-sideview",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
         "axios": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "name": "Ricky",
     "url": "https://github.com/Rickaym"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "Rickaym",
   "engines": {
     "vscode": "^1.68.0"

--- a/scripts/contract-test.js
+++ b/scripts/contract-test.js
@@ -54,6 +54,33 @@ function check(name, fn) {
   }
 }
 
+// 0. render inside a directory containing a space: the wrapped log path
+// must reconstruct with the space intact (0.4.1 regression, issue #136)
+{
+  const cwd = path.join(freshDir("spaced"), "my scenes");
+  fs.mkdirSync(cwd);
+  fs.copyFileSync(
+    path.join(FIXTURES, "scenes", "video_scene.py"),
+    path.join(cwd, "scene.py")
+  );
+  const render = run(["-ql", "scene.py", "VideoScene"], cwd);
+  const logbook = render.stdout + render.stderr;
+
+  check("spaced path: parsed log path exists on disk", () => {
+    const parsed = parseMediaOutputFromLog(logbook);
+    assert.ok(parsed, `no File ready entry found in:\n${logbook}`);
+    assert.ok(
+      fs.existsSync(parsed.mediaPath),
+      `parsed path does not exist: ${parsed.mediaPath}`
+    );
+    assert.ok(
+      parsed.mediaPath.includes("my scenes"),
+      `space was stripped from: ${parsed.mediaPath}`
+    );
+  });
+  fs.rmSync(path.dirname(cwd), { recursive: true, force: true });
+}
+
 // 1. video render: the logged path must parse and exist
 {
   const cwd = freshDir("video");

--- a/src/mediaResolution.ts
+++ b/src/mediaResolution.ts
@@ -12,10 +12,11 @@ export type ResolvedMedia = {
   mediaPath: string;
 };
 
-// manim wraps long paths across lines inside the quotes; strip the
-// wrapping whitespace to recover the real path
+// manim's rich console wraps long paths across lines inside the quotes,
+// indenting the continuation. Strip only newline-adjacent whitespace so
+// genuine spaces inside the path survive (e.g. "Manim Projects").
 function cleanPath(p: string): string {
-  return p.replace(/ |\r|\n/g, "");
+  return p.replace(/[ \t]*\r?\n[ \t]*/g, "");
 }
 
 /**

--- a/src/mediaResolution.ts
+++ b/src/mediaResolution.ts
@@ -13,10 +13,39 @@ export type ResolvedMedia = {
 };
 
 // manim's rich console wraps long paths across lines inside the quotes,
-// indenting the continuation. Strip only newline-adjacent whitespace so
-// genuine spaces inside the path survive (e.g. "Manim Projects").
-function cleanPath(p: string): string {
-  return p.replace(/[ \t]*\r?\n[ \t]*/g, "");
+// indenting the continuation. A long token is broken mid-word, but a path
+// containing a space is word-wrapped AT the space, which the wrap consumes.
+// Reconstruction is therefore ambiguous: each line break may or may not
+// stand for a real space.
+function wrapSegments(p: string): string[] {
+  return p
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((s) => s.replace(/^[ \t]+|[ \t]+$/g, ""));
+}
+
+// All plausible reconstructions: every combination of "" or " " at each
+// line-break junction, starting with the all-joined form. Bounded so a
+// pathological log cannot explode combinatorially.
+function pathCandidates(p: string): string[] {
+  const segments = wrapSegments(p);
+  const junctions = segments.length - 1;
+  if (junctions <= 0) {
+    return [segments[0] ?? ""];
+  }
+  const maxJunctions = 10;
+  if (junctions > maxJunctions) {
+    return [segments.join("")];
+  }
+  const candidates: string[] = [];
+  for (let mask = 0; mask < 1 << junctions; mask++) {
+    let joined = segments[0];
+    for (let i = 0; i < junctions; i++) {
+      joined += (mask & (1 << i) ? " " : "") + segments[i + 1];
+    }
+    candidates.push(joined);
+  }
+  return candidates;
 }
 
 /**
@@ -25,21 +54,28 @@ function cleanPath(p: string): string {
  * Prefers an image entry if present; otherwise takes the last "File ready
  * at" entry, since videos log one line per partial movie file plus a final
  * entry for the merged output.
+ *
+ * @param exists used to disambiguate wrapped paths against the filesystem;
+ * defaults to fs.existsSync. The first existing candidate wins, otherwise
+ * the fully-joined reconstruction is returned.
  */
 export function parseMediaOutputFromLog(
-  stdoutLogbook: string
+  stdoutLogbook: string,
+  exists: (p: string) => boolean = fs.existsSync
 ): ResolvedMedia | null {
   const matches = [...stdoutLogbook.matchAll(RE_FILE_READY)];
   if (matches.length === 0) {
     return null;
   }
   const imageEntry = matches.find((m) =>
-    cleanPath(m.groups?.path ?? "").endsWith(".png")
+    wrapSegments(m.groups?.path ?? "").join("").endsWith(".png")
   );
   const chosen = imageEntry ?? matches[matches.length - 1];
+  const candidates = pathCandidates(chosen.groups?.path ?? "");
+  const mediaPath = candidates.find(exists) ?? candidates[0];
   return {
     isImage: !!imageEntry,
-    mediaPath: cleanPath(chosen.groups?.path ?? ""),
+    mediaPath,
   };
 }
 

--- a/src/test/fixtures/logs/wrapped_spaced_path.log
+++ b/src/test/fixtures/logs/wrapped_spaced_path.log
@@ -1,0 +1,9 @@
+                    INFO     Combining to Movie file.   scene_file_writer.py:617
+                    INFO                                scene_file_writer.py:737
+                             File ready at
+                             'C:\Users\Jake Smith\man
+                             im_projects\media\videos
+                             \scene\480p15\Demo Scene
+                             .mp4'
+
+                    INFO     Rendered DemoScene                   scene.py:247

--- a/src/test/unit/mediaResolution.test.ts
+++ b/src/test/unit/mediaResolution.test.ts
@@ -37,6 +37,26 @@ test("recovers a path wrapped across log lines (issue #132 shape)", () => {
   );
 });
 
+test("preserves genuine spaces in paths while unwrapping (0.4.1 regression)", () => {
+  const result = parseMediaOutputFromLog(loadLog("wrapped_spaced_path.log"));
+  assert.ok(result);
+  assert.strictEqual(
+    result.mediaPath,
+    "C:\\Users\\Jake Smith\\manim_projects\\media\\videos\\scene\\480p15\\Demo Scene.mp4"
+  );
+});
+
+test("single-line path with spaces is untouched", () => {
+  const result = parseMediaOutputFromLog(
+    "INFO  File ready at '/proj/My Scenes/media/videos/main/480p15/Demo.mp4'"
+  );
+  assert.ok(result);
+  assert.strictEqual(
+    result.mediaPath,
+    "/proj/My Scenes/media/videos/main/480p15/Demo.mp4"
+  );
+});
+
 test("prefers the merged output over partial movie files", () => {
   const result = parseMediaOutputFromLog(loadLog("partials_then_final.log"));
   assert.ok(result);

--- a/src/test/unit/mediaResolution.test.ts
+++ b/src/test/unit/mediaResolution.test.ts
@@ -46,6 +46,21 @@ test("preserves genuine spaces in paths while unwrapping (0.4.1 regression)", ()
   );
 });
 
+test("wrap at a real space is recovered via the exists predicate", () => {
+  // rich word-wraps AT a space and the wrap consumes it; only the
+  // filesystem can disambiguate
+  const log =
+    "INFO  File ready at '/tmp/my\n                             scenes/media/Demo.mp4'";
+  const spaced = "/tmp/my scenes/media/Demo.mp4";
+  const result = parseMediaOutputFromLog(log, (p) => p === spaced);
+  assert.ok(result);
+  assert.strictEqual(result.mediaPath, spaced);
+  // without a matching file the joined form is the fallback
+  const fallback = parseMediaOutputFromLog(log, () => false);
+  assert.ok(fallback);
+  assert.strictEqual(fallback.mediaPath, "/tmp/myscenes/media/Demo.mp4");
+});
+
 test("single-line path with spaces is untouched", () => {
   const result = parseMediaOutputFromLog(
     "INFO  File ready at '/proj/My Scenes/media/videos/main/480p15/Demo.mp4'"


### PR DESCRIPTION
Fixes the 0.4.x regression reported in #136: cleanPath stripped every space when reconstructing wrapped File-ready paths from manim's log, mangling any output path with a space in it. Now only newline-adjacent whitespace is removed. Adds a wrapped-spaced-path log fixture with unit tests and a contract case that renders inside a directory containing a space. Bumps to 0.4.2.